### PR TITLE
Add newtonsoft support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,11 @@ jobs:
     - name: Set version
       # Gets the numeric version from a tag (e.g. v1.2.3 -> 1.2.3)
       run: echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/tags/v} 
-    - name: Create Nuget package
+    - name: Create Saunter Nuget package
       run: dotnet pack ./src/Saunter/Saunter.csproj --configuration Release -p:Version="$RELEASE_VERSION" --output ./build
-    - name: Push Nuget package to Nuget.org
+    - name: Create Saunter NewtonsoftJson Nuget package
+      run: dotnet pack ./src/Saunter.NewtonsoftJson/Saunter.NewtonsoftJson.csproj --configuration Release -p:Version="$RELEASE_VERSION" --output ./build
+    - name: Push Nuget packages to Nuget.org
       env:
         NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }} 
       run: dotnet nuget push ./build/*.nupkg --api-key $NUGET_API_KEY --source "https://api.nuget.org/v3/index.json"

--- a/Saunter.sln
+++ b/Saunter.sln
@@ -16,9 +16,11 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StreetlightsAPI", "examples\StreetlightsAPI\StreetlightsAPI.csproj", "{F188D4A7-BBCB-464F-A370-2BD84D18EA79}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E0D34C77-924E-4F6B-9289-5A2F07D125A8}"
-ProjectSection(SolutionItems) = preProject
-	README.md = README.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Saunter.NewtonsoftJson", "src\Saunter.NewtonsoftJson\Saunter.NewtonsoftJson.csproj", "{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,10 +71,23 @@ Global
 		{F188D4A7-BBCB-464F-A370-2BD84D18EA79}.Release|x64.Build.0 = Release|Any CPU
 		{F188D4A7-BBCB-464F-A370-2BD84D18EA79}.Release|x86.ActiveCfg = Release|Any CPU
 		{F188D4A7-BBCB-464F-A370-2BD84D18EA79}.Release|x86.Build.0 = Release|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Debug|x64.Build.0 = Debug|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Debug|x86.Build.0 = Debug|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Release|x64.ActiveCfg = Release|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Release|x64.Build.0 = Release|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Release|x86.ActiveCfg = Release|Any CPU
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{240F263C-4F9B-40E0-8392-1FDB324153F6} = {28D4C365-FDED-49AE-A97D-36202E24A55A}
 		{3ADB27EF-7C80-40EB-AFC6-5D06D415FFAB} = {6491E321-2D02-44AB-9116-D722FE169595}
 		{F188D4A7-BBCB-464F-A370-2BD84D18EA79} = {6ABD4842-47AF-49A5-B057-0EBA64416789}
+		{C5E47B10-87AA-48DE-B81D-8A791C0AC5A7} = {28D4C365-FDED-49AE-A97D-36202E24A55A}
 	EndGlobalSection
 EndGlobal

--- a/src/Saunter.NewtonsoftJson/Properties/AssemblyInfo.cs
+++ b/src/Saunter.NewtonsoftJson/Properties/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Saunter.NewtonsoftJson")]
 [assembly: InternalsVisibleTo("Saunter.Tests")]

--- a/src/Saunter.NewtonsoftJson/Saunter.NewtonsoftJson.csproj
+++ b/src/Saunter.NewtonsoftJson/Saunter.NewtonsoftJson.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IsPackable>true</IsPackable>
+    <PackageId>Saunter.NewtonsoftJson</PackageId>
+    <Title>Saunter.NewtonsoftJson</Title>
+    <PackageIcon>logo.png</PackageIcon>
+    <Authors>tehmantra</Authors>
+    <Description>Code-first AsyncAPI documentation - NewtonsoftJson support</Description>
+    <PackageTags>asyncapi;aspnetcore;openapi;documentation;amqp</PackageTags>
+    <RepositoryUrl>https://github.com/tehmantra/saunter</RepositoryUrl>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageProjectUrl>https://github.com/tehmantra/saunter</PackageProjectUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\assets\logo.png" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- TODO transform to package reference as soon as the options are available as nuget package -->
+    <ProjectReference Include="..\Saunter\Saunter.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+
+    <!-- Development Dependencies -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/src/Saunter.NewtonsoftJson/SaunterNewtonsoftJsonServiceCollectionExtensions.cs
+++ b/src/Saunter.NewtonsoftJson/SaunterNewtonsoftJsonServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+﻿using System.Reflection;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using Saunter.Utils;
+
+namespace Saunter.NewtonsoftJson
+{
+    public static class SaunterNewtonsoftJsonServiceCollectionExtensions
+    {
+        public static AsyncApiOptions UseNewtonsoftJson(this AsyncApiOptions options)
+        {
+            options.PropertyNameSelector = prop =>
+            {
+                var name = prop.GetCustomAttribute<JsonPropertyAttribute>()?.PropertyName
+                    ?? prop.GetCustomAttribute<DataMemberAttribute>()?.Name
+                    ?? prop.Name;
+                return new CamelCaseNamingStrategy().GetPropertyName(name, false);
+            };
+
+            options.PropertyFilter = prop => prop.GetCustomAttribute<JsonIgnoreAttribute>() == null;
+
+            options.UseEnumMemberName = type =>
+            {
+                var jsonConverterAttribute = type.GetCustomAttribute<JsonConverterAttribute>();
+                return jsonConverterAttribute?.ConverterType == typeof(StringEnumConverter);
+            };
+
+            options.EnumMemberNameSelector = (type, val) =>
+            {
+                var converterType = type.GetCustomAttribute<JsonConverterAttribute>()?.ConverterType;
+                if (converterType == typeof(StringEnumConverter))
+                {
+                    var enumMemberAttribute = val.GetCustomAttribute<EnumMemberAttribute>();
+                    if (enumMemberAttribute?.Value != null)
+                    {
+                        return enumMemberAttribute.Value;
+                    }
+                }
+
+                return val.ToString();
+            };
+
+            return options;
+        }
+    }
+}

--- a/test/Saunter.Tests/NewtonsoftJson/Generation/SchemaGeneration/SchemaGenerationTests.cs
+++ b/test/Saunter.Tests/NewtonsoftJson/Generation/SchemaGeneration/SchemaGenerationTests.cs
@@ -1,0 +1,124 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Saunter.Generation.SchemaGeneration;
+using Saunter.NewtonsoftJson;
+using Shouldly;
+using Xunit;
+
+namespace Saunter.Tests.NewtonsoftJson.Generation.SchemaGeneration
+{
+    public class SchemaGenerationTests
+    {
+        private readonly ISchemaRepository _schemaRepository;
+        private readonly SchemaGenerator _schemaGenerator;
+
+        public SchemaGenerationTests()
+        {
+            _schemaRepository = new SchemaRepository();
+            var options = new AsyncApiOptions();
+            options.UseNewtonsoftJson();
+
+            _schemaGenerator = new SchemaGenerator(Options.Create(options));
+        }
+
+        [Fact]
+        public void GenerateSchema_GenerateSchemaFromTypeWithProperties_GeneratesSchemaCorrectly()
+        {
+            var type = typeof(Foo);
+
+            var schema = _schemaGenerator.GenerateSchema(type, _schemaRepository);
+
+            schema.ShouldNotBeNull();
+            _schemaRepository.Schemas.ShouldNotBeNull();
+            _schemaRepository.Schemas.ContainsKey("foo").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Required.Count.ShouldBe(1);
+            _schemaRepository.Schemas["foo"].Required.Contains("id").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.Count.ShouldBe(5);
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("id").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("bar").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("fooType").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("hello").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("myworld").ShouldBeTrue();
+            _schemaRepository.Schemas.ContainsKey("bar").ShouldBeTrue();
+            _schemaRepository.Schemas["bar"].Properties.Count.ShouldBe(2);
+            _schemaRepository.Schemas["bar"].Properties.ContainsKey("name").ShouldBeTrue();
+            _schemaRepository.Schemas["bar"].Properties.ContainsKey("cost").ShouldBeTrue();
+        }
+
+        [Fact]
+        public void GenerateSchema_GenerateSchemaFromTypeWithFields_GeneratesSchemaCorrectly()
+        {
+            var type = typeof(Book);
+
+            var schema = _schemaGenerator.GenerateSchema(type, _schemaRepository);
+
+            schema.ShouldNotBeNull();
+            _schemaRepository.Schemas.ShouldNotBeNull();
+            _schemaRepository.Schemas.ContainsKey("book").ShouldBeTrue();
+            _schemaRepository.Schemas["book"].Properties.Count.ShouldBe(4);
+            _schemaRepository.Schemas.ContainsKey("foo").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Required.Count.ShouldBe(1);
+            _schemaRepository.Schemas["foo"].Required.Contains("id").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.Count.ShouldBe(5);
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("id").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("bar").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("fooType").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("hello").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Properties.ContainsKey("myworld").ShouldBeTrue();
+        }
+    }
+
+    public class Foo
+    {
+        [Required]
+        public Guid Id { get; set; }
+
+        [JsonIgnore]
+        public string Ignore { get; set; }
+
+        public Bar Bar { get; set; }
+
+        [JsonProperty("hello")]
+        public string HelloWorld { get; set; }
+
+        [DataMember(Name = "myworld")]
+        public string World { get; set; }
+
+        public FooType FooType { get; set; }
+    }
+
+    public enum FooType
+    {
+        Foo,
+        Bar
+    }
+
+    public class Bar
+    {
+        public string Name { get; set; }
+
+        public decimal? Cost { get; set; }
+    }
+
+    public class Book
+    {
+        public readonly string Name;
+
+        public readonly string Author;
+
+        public readonly int NumberOfPages;
+
+        public readonly Foo Foo;
+
+        public Book(string name, string author, int numberOfPages, Foo foo)
+        {
+            Author = author;
+            Name = name;
+            NumberOfPages = numberOfPages;
+            Foo = foo;
+        }
+    }
+}

--- a/test/Saunter.Tests/NewtonsoftJson/Utils/ReflectionTests.cs
+++ b/test/Saunter.Tests/NewtonsoftJson/Utils/ReflectionTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Saunter.NewtonsoftJson;
+using Saunter.Utils;
+using Shouldly;
+using Xunit;
+
+namespace Saunter.Tests.NewtonsoftJson.Utils
+{
+    public class ReflectionTests
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        private enum StringEnumConverterEnum
+        {
+            Hello,
+            [EnumMember(Value = "world")]
+            World,
+        }
+
+        [Theory]
+        [InlineData(typeof(StringEnumConverterEnum), new[] { "Hello", "world" })]
+        public void IsEnum_True_WhenTypeIsJsonStringEnumConverterEnum(Type type, string[] members)
+        {
+            var options = new AsyncApiOptions();
+            options.UseNewtonsoftJson();
+            type.IsEnum(options, out var actualMembers).ShouldBeTrue();
+            actualMembers.MemberType.ShouldBe(typeof(string));
+            actualMembers.Members.ShouldBe(members);
+        }
+
+        private enum SomeEnum
+        {
+            Hello = 0,
+            World = 1,
+        }
+
+        [Theory]
+        [InlineData(typeof(SomeEnum), new[] { 0, 1 })]
+        public void IsEnum_True_WhenTypeIsEnum(Type type, int[] members)
+        {
+            var options = new AsyncApiOptions();
+            options.UseNewtonsoftJson();
+            type.IsEnum(options, out var actualMembers).ShouldBeTrue();
+            actualMembers.MemberType.ShouldBe(typeof(int));
+            actualMembers.Members.ShouldBe(members);
+        }
+    }
+}

--- a/test/Saunter.Tests/Saunter.Tests.csproj
+++ b/test/Saunter.Tests/Saunter.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Saunter.NewtonsoftJson\Saunter.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\..\src\Saunter\Saunter.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
closes #48 

it's not yet finished as it expects the new options to be available in the nuget package.

controversial is the usage of "internalsvisibleto": this is used to prevent code duplication from the reflection extensions.