### PR TITLE
Allow oneOf messages

### DIFF
--- a/src/Saunter/Attributes/MessageAttribute.cs
+++ b/src/Saunter/Attributes/MessageAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Saunter.Attributes
 {
-    [AttributeUsage(AttributeTargets.Method)]
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class MessageAttribute : Attribute
     {
         public MessageAttribute(Type payloadType)

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -197,6 +197,11 @@ namespace Saunter.Generation
                 }
             }
 
+            if (messages.OneOf.Count == 1)
+            {
+                operation.Message = messages.OneOf.First();
+            }
+
             return operation;
         }
 

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -183,15 +183,18 @@ namespace Saunter.Generation
             var methodsWithMessageAttribute = type.DeclaredMethods
                 .Select(method => new
                 {
-                    Message = method.GetCustomAttribute<MessageAttribute>(),
+                    MessageAttributes = method.GetCustomAttributes<MessageAttribute>(),
                     Method = method,
                 })
-                .Where(mm => mm.Message != null);
+                .Where(mm => mm.MessageAttributes.Any());
 
-            foreach (var mm in methodsWithMessageAttribute)
+            foreach (MessageAttribute messageAttribute in methodsWithMessageAttribute.SelectMany(x => x.MessageAttributes))
             {
-                var message = GenerateMessageFromAttribute(mm.Message, schemaRepository);
-                messages.OneOf.Add(message);
+                Message message = GenerateMessageFromAttribute(messageAttribute, schemaRepository);
+                if (message != null)
+                {
+                    messages.OneOf.Add(message);
+                }
             }
 
             return operation;

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
@@ -45,6 +45,38 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             messages.OneOf.ShouldContain(m => m.Name == "tenantRemoved");
         }
 
+        [Fact]
+        public void GenerateDocument_GeneratesDocumentWithMultipleMessagesPerChannelInTheSameMethod()
+        {
+            // Arrange
+            var options = new AsyncApiOptions();
+            var schemaGenerator = new SchemaGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator(Options.Create(options), schemaGenerator);
+            
+            // Act
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() });
+
+            // Assert
+            document.ShouldNotBeNull();
+            document.Channels.Count.ShouldBe(1);
+
+            var channel = document.Channels.First();
+            channel.Key.ShouldBe("asw.tenant_service.tenants_history");
+            channel.Value.Description.ShouldBe("Tenant events.");
+            
+            var publish = channel.Value.Publish;
+            publish.ShouldNotBeNull();
+            publish.OperationId.ShouldBe("TenantMessagePublisher");
+            publish.Summary.ShouldBe("Publish domains events about tenants.");
+
+            var messages = publish.Message.ShouldBeOfType<Messages>();
+            messages.OneOf.Count.ShouldBe(3);
+            
+            messages.OneOf.ShouldContain(m => m.Name == "anyTenantCreated");
+            messages.OneOf.ShouldContain(m => m.Name == "anyTenantUpdated");
+            messages.OneOf.ShouldContain(m => m.Name == "anyTenantRemoved");
+        }
+
         [AsyncApi]
         [Channel("asw.tenant_service.tenants_history", Description = "Tenant events.")]
         [SubscribeOperation(OperationId = "TenantMessageConsumer", Summary = "Subscribe to domains events about tenants.")]
@@ -58,6 +90,20 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
 
             [Message(typeof(TenantRemoved))]
             public void SubscribeTenantRemovedEvent(Guid tenantId, TenantRemoved evnt) {}
+        }
+
+        [AsyncApi]
+        [Channel("asw.tenant_service.tenants_history", Description = "Tenant events.")]
+        [PublishOperation(OperationId = "TenantMessagePublisher", Summary = "Publish domains events about tenants.")]
+        public class TenantMessagePublisher : ITenantMessagePublisher
+        {
+            [Message(typeof(AnyTenantCreated))]
+            [Message(typeof(AnyTenantUpdated))]
+            [Message(typeof(AnyTenantRemoved))]
+            public void PublishTenantEvent<TEvent>(Guid tenantId, TEvent @event)
+                where TEvent : IEvent
+            {
+            }
         }
     }
     

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Options;
+using Saunter.AsyncApiSchema.v2;
+using Saunter.Attributes;
+using Saunter.Generation;
+using Saunter.Generation.SchemaGeneration;
+using Shouldly;
+using Xunit;
+
+namespace Saunter.Tests.Generation.DocumentGeneratorTests
+{
+    public class MethodAttributesTests
+    {
+        [Fact]
+        public void GenerateDocument_GeneratesDocumentWithMultipleMessagesPerChannel()
+        {
+            // Arrange
+            var options = new AsyncApiOptions();
+            var schemaGenerator = new SchemaGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator(Options.Create(options), schemaGenerator);
+            
+            // Act
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() });
+            
+            // Assert
+            document.ShouldNotBeNull();
+            document.Channels.Count.ShouldBe(1);
+
+            var channel = document.Channels.First();
+            channel.Key.ShouldBe("asw.tenant_service.tenants_history");
+            channel.Value.Description.ShouldBe("Tenant events.");
+            
+            var publish = channel.Value.Publish;
+            publish.ShouldNotBeNull();
+            publish.OperationId.ShouldBe("TenantMessagePublisher");
+            publish.Summary.ShouldBe("Publish domains events about tenants.");
+
+            var messages = publish.Message.ShouldBeOfType<Messages>();
+            messages.OneOf.Count.ShouldBe(3);
+            
+            messages.OneOf.ShouldContain(m => m.Name == "anyTenantCreated");
+            messages.OneOf.ShouldContain(m => m.Name == "anyTenantUpdated");
+            messages.OneOf.ShouldContain(m => m.Name == "anyTenantRemoved");
+        }
+
+        [AsyncApi]
+        public class TenantMessagePublisher : ITenantMessagePublisher
+        {
+            [Channel("asw.tenant_service.tenants_history", Description = "Tenant events.")]
+            [PublishOperation(OperationId = "TenantMessagePublisher", Summary = "Publish domains events about tenants.")]
+            [Message(typeof(AnyTenantCreated))]
+            [Message(typeof(AnyTenantUpdated))]
+            [Message(typeof(AnyTenantRemoved))]
+            public void PublishTenantEvent<TEvent>(Guid tenantId, TEvent @event)
+                where TEvent : IEvent
+            {
+            }
+        }
+    }
+
+    public class AnyTenantCreated : IEvent {}
+    
+    public class AnyTenantUpdated : IEvent {}
+    
+    public class AnyTenantRemoved : IEvent {}
+
+    public interface IEvent {}
+    
+    public interface ITenantMessagePublisher
+    {
+        void PublishTenantEvent<TEvent>(Guid tenantId, TEvent @event)
+            where TEvent : IEvent;
+    }
+}


### PR DESCRIPTION
To cover issue #69.

In addition:
- If the operation is indicated at class level and there is only a single message, it will not use a `oneOf` (`Messages`) and it will use a single `Message`.