### PR TITLE
Add supported exchange types to the specification

### DIFF
--- a/src/Saunter/AsyncApiSchema/v2/Bindings/Amqp/AmqpChannelBinding.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Bindings/Amqp/AmqpChannelBinding.cs
@@ -61,4 +61,17 @@ namespace Saunter.AsyncApiSchema.v2.Bindings.Amqp
         [EnumMember(Value = "queue")]
         Queue,
     }
+
+    public static class AmqpChannelBindingExchangeType
+    {
+        public const string Topic = "topic";
+
+        public const string Direct = "direct";
+
+        public const string Fanout = "fanout";
+
+        public const string Default = "default";
+
+        public const string Headers = "headers";
+    }
 }


### PR DESCRIPTION
To cover #73 

Use example:
```csharp
channelItem.Bindings = new ChannelBindings 
{
    Amqp = new AmqpChannelBinding
    {
        Is = AmqpChannelBindingIs.RoutingKey,
        Exchange = new AmqpChannelBindingExchange
        {
            Name = "anyName",
            Type = AmqpChannelBindingExchangeType.Fanout,
            Durable = true,
            AutoDelete = false,
            VirtualHost = "anyVirtualHost",
        },
    },
};
```