### PR TITLE
Schema properties can be marked as required using attributes

### DIFF
--- a/src/Saunter/Generation/SchemaGeneration/SchemaGenerator.cs
+++ b/src/Saunter/Generation/SchemaGeneration/SchemaGenerator.cs
@@ -92,11 +92,11 @@ namespace Saunter.Generation.SchemaGeneration
                     s2.MaxLength = member.GetMaxLength();
                     s2.Pattern = member.GetPattern();
                     s2.Example = member.GetExample();
+                }
 
-                    if (member.GetIsRequired())
-                    {
-                        requiredMembers.Add(memberName);
-                    }
+                if (member.GetIsRequired())
+                {
+                    requiredMembers.Add(memberName);
                 }
 
                 schema.Properties.Add(memberName, memberSchema);

--- a/test/Saunter.Tests/Generation/SchemaGeneration/SchemaGenerationTests.cs
+++ b/test/Saunter.Tests/Generation/SchemaGeneration/SchemaGenerationTests.cs
@@ -32,8 +32,9 @@ namespace Saunter.Tests.Generation.SchemaGeneration
             schema.ShouldNotBeNull();
             _schemaRepository.Schemas.ShouldNotBeNull();
             _schemaRepository.Schemas.ContainsKey("foo").ShouldBeTrue();
-            _schemaRepository.Schemas["foo"].Required.Count.ShouldBe(1);
+            _schemaRepository.Schemas["foo"].Required.Count.ShouldBe(2);
             _schemaRepository.Schemas["foo"].Required.Contains("id").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Required.Contains("bar").ShouldBeTrue();
             _schemaRepository.Schemas["foo"].Properties.Count.ShouldBe(5);
             _schemaRepository.Schemas["foo"].Properties.ContainsKey("id").ShouldBeTrue();
             _schemaRepository.Schemas["foo"].Properties.ContainsKey("bar").ShouldBeTrue();
@@ -58,8 +59,9 @@ namespace Saunter.Tests.Generation.SchemaGeneration
             _schemaRepository.Schemas.ContainsKey("book").ShouldBeTrue();
             _schemaRepository.Schemas["book"].Properties.Count.ShouldBe(4);
             _schemaRepository.Schemas.ContainsKey("foo").ShouldBeTrue();
-            _schemaRepository.Schemas["foo"].Required.Count.ShouldBe(1);
+            _schemaRepository.Schemas["foo"].Required.Count.ShouldBe(2);
             _schemaRepository.Schemas["foo"].Required.Contains("id").ShouldBeTrue();
+            _schemaRepository.Schemas["foo"].Required.Contains("bar").ShouldBeTrue();
             _schemaRepository.Schemas["foo"].Properties.Count.ShouldBe(5);
             _schemaRepository.Schemas["foo"].Properties.ContainsKey("id").ShouldBeTrue();
             _schemaRepository.Schemas["foo"].Properties.ContainsKey("bar").ShouldBeTrue();
@@ -77,6 +79,7 @@ namespace Saunter.Tests.Generation.SchemaGeneration
         [JsonIgnore]
         public string Ignore { get; set; }
 
+        [Required]
         public Bar Bar { get; set; }
 
         [JsonPropertyName("hello")]


### PR DESCRIPTION
Allow marking with RequiredAttribute the required properties which are classes, interfaces or structs.

To cover #81.