### PR TITLE
Support for Subscribe and Publish operations of the same Channel in different classes

### DIFF
--- a/src/Saunter/AsyncApiSchema/v2/Channels.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Channels.cs
@@ -1,6 +1,7 @@
+using System;
 using System.Collections.Generic;
 
-namespace Saunter.AsyncApiSchema.v2 
+namespace Saunter.AsyncApiSchema.v2
 {
     public class Channels : Dictionary<ChannelsFieldName, ChannelItem>
     {
@@ -10,11 +11,30 @@ namespace Saunter.AsyncApiSchema.v2
             {
                 return;
             }
-            
+
             foreach (var channel in channels)
             {
-                Add(channel.Key, channel.Value);
+                AddOrAppend(channel.Key, channel.Value);
             }
+        }
+
+        public void AddOrAppend(ChannelsFieldName key, ChannelItem channel)
+        {
+            if (ContainsKey(key))
+            {
+                var existingItem = this[key];
+                if (existingItem.Publish == null && channel.Publish != null)
+                    this[key].Publish = channel.Publish;
+                else if (existingItem.Publish != null && channel.Publish != null)
+                    throw new ArgumentException($"An item with the same key and with an existing publish operation has already been added to the channel collection.");
+
+                if (existingItem.Subscribe == null && channel.Subscribe != null)
+                    this[key].Subscribe = channel.Subscribe;
+                else if (existingItem.Subscribe != null && channel.Subscribe != null)
+                    throw new ArgumentException($"An item with the same key and with an existing subscribe operation has already been added to the channel collection.");
+            }
+            else
+                this[key] = channel;
         }
     }
 }

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -21,13 +21,13 @@ namespace Saunter.Generation
             _schemaGenerator = schemaGenerator;
             _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
-        
+
         public AsyncApiSchema.v2.AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes)
         {
             var schemaRepository = new SchemaRepository();
 
             var asyncApiSchema = _options.AsyncApi;
-            
+
             asyncApiSchema.Channels = GenerateChannels(asyncApiTypes, schemaRepository);
             asyncApiSchema.Components.Schemas = schemaRepository.Schemas;
 
@@ -40,25 +40,22 @@ namespace Saunter.Generation
             return asyncApiSchema;
         }
 
-
-        
-        
         /// <summary>
-        /// Generate the Channels section of an AsyncApi schema. 
+        /// Generate the Channels section of an AsyncApi schema.
         /// </summary>
         private Channels GenerateChannels(TypeInfo[] asyncApiTypes, ISchemaRepository schemaRepository)
         {
             var channels = new Channels();
-            
+
             channels.AddRange(GenerateChannelsFromMethods(asyncApiTypes, schemaRepository));
             channels.AddRange(GenerateChannelsFromClasses(asyncApiTypes, schemaRepository));
 
             return channels;
         }
 
-
         /// <summary>
-        /// Generate the Channels section of the AsyncApi schema from the <see cref="ChannelAttribute"/> on methods.
+        /// Generate the Channels section of the AsyncApi schema from the
+        /// <see cref="ChannelAttribute"/> on methods.
         /// </summary>
         private Channels GenerateChannelsFromMethods(IEnumerable<TypeInfo> asyncApiTypes, ISchemaRepository schemaRepository)
         {
@@ -76,14 +73,14 @@ namespace Saunter.Generation
             foreach (var mc in methodsWithChannelAttribute)
             {
                 var channelItem = new ChannelItem
-                {              
+                {
                     Description = mc.Channel.Description,
                     Parameters = mc.Channel.Parameters,
                     Publish = GenerateOperationFromMethod(mc.Method, schemaRepository, OperationType.Publish),
                     Subscribe = GenerateOperationFromMethod(mc.Method, schemaRepository, OperationType.Subscribe),
-                }; 
+                };
                 channels.Add(mc.Channel.Name, channelItem);
-                
+
                 var context = new ChannelItemFilterContext(mc.Method, schemaRepository, mc.Channel);
                 foreach (var filter in _options.ChannelItemFilters)
                 {
@@ -95,7 +92,8 @@ namespace Saunter.Generation
         }
 
         /// <summary>
-        /// Generate the Channels section of the AsyncApi schema from the <see cref="ChannelAttribute"/> on classes.
+        /// Generate the Channels section of the AsyncApi schema from the
+        /// <see cref="ChannelAttribute"/> on classes.
         /// </summary>
         private Channels GenerateChannelsFromClasses(IEnumerable<TypeInfo> asyncApiTypes, ISchemaRepository schemaRepository)
         {
@@ -116,11 +114,11 @@ namespace Saunter.Generation
                     Description = cc.Channel.Description,
                     Parameters = cc.Channel.Parameters,
                     Publish = GenerateOperationFromClass(cc.Type, schemaRepository, OperationType.Publish),
-                    Subscribe = GenerateOperationFromClass(cc.Type, schemaRepository, OperationType.Subscribe),                    
+                    Subscribe = GenerateOperationFromClass(cc.Type, schemaRepository, OperationType.Subscribe),
                 };
-                
-                channels.Add(cc.Channel.Name, channelItem);
-                
+
+                channels.AddOrAppend(cc.Channel.Name, channelItem);
+
                 var context = new ChannelItemFilterContext(cc.Type, schemaRepository, cc.Channel);
                 foreach (var filter in _options.ChannelItemFilters)
                 {
@@ -130,8 +128,6 @@ namespace Saunter.Generation
 
             return channels;
         }
-        
-
 
         /// <summary>
         /// Generate the an operation of an AsyncApi Channel for the given method.
@@ -148,7 +144,7 @@ namespace Saunter.Generation
             var message = messageAttribute != null
                 ? GenerateMessageFromAttribute(messageAttribute, schemaRepository)
                 : GenerateMessageFromType(operationAttribute.MessagePayloadType, schemaRepository);
-            
+
             var operation = new Operation
             {
                 OperationId = operationAttribute.OperationId ?? method.Name,
@@ -165,7 +161,6 @@ namespace Saunter.Generation
 
             return operation;
         }
-
 
         /// <summary>
         /// Generate the an operation of an AsyncApi Channel for the given class.
@@ -211,11 +206,11 @@ namespace Saunter.Generation
                 case OperationType.Publish:
                     var publishOperationAttribute = typeOrMethod.GetCustomAttribute<PublishOperationAttribute>();
                     return (OperationAttribute) publishOperationAttribute;
-                
+
                 case OperationType.Subscribe:
                     var subscribeOperationAttribute = typeOrMethod.GetCustomAttribute<SubscribeOperationAttribute>();
                     return (OperationAttribute) subscribeOperationAttribute;
-                
+
                 default:
                     return null;
             }
@@ -227,7 +222,7 @@ namespace Saunter.Generation
             {
                 return null;
             }
-            
+
             var message = new Message
             {
                 Payload = _schemaGenerator.GenerateSchema(messageAttribute.PayloadType, schemaRepository),
@@ -239,7 +234,6 @@ namespace Saunter.Generation
 
             return message;
         }
-        
 
         private Message GenerateMessageFromType(Type payloadType, ISchemaRepository schemaRepository)
         {
@@ -247,7 +241,7 @@ namespace Saunter.Generation
             {
                 return null;
             }
-            
+
             var message = new Message
             {
                 Payload = _schemaGenerator.GenerateSchema(payloadType, schemaRepository),

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
@@ -20,10 +20,10 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var options = new AsyncApiOptions();
             var schemaGenerator = new SchemaGenerator(Options.Create(options));
             var documentGenerator = new DocumentGenerator(Options.Create(options), schemaGenerator);
-            
+
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessageConsumer).GetTypeInfo() });
-            
+            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() });
+
             // Assert
             document.ShouldNotBeNull();
             document.Channels.Count.ShouldBe(1);
@@ -31,7 +31,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var channel = document.Channels.First();
             channel.Key.ShouldBe("asw.tenant_service.tenants_history");
             channel.Value.Description.ShouldBe("Tenant events.");
-            
+
             var subscribe = channel.Value.Subscribe;
             subscribe.ShouldNotBeNull();
             subscribe.OperationId.ShouldBe("TenantMessageConsumer");
@@ -39,10 +39,58 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
 
             var messages = subscribe.Message.ShouldBeOfType<Messages>();
             messages.OneOf.Count.ShouldBe(3);
-            
+
             messages.OneOf.ShouldContain(m => m.Name == "tenantCreated");
             messages.OneOf.ShouldContain(m => m.Name == "tenantUpdated");
             messages.OneOf.ShouldContain(m => m.Name == "tenantRemoved");
+        }
+
+        [Fact]
+        public void GetDocument_WhenMultipleClassesUseSameChannelKey_GeneratesDocumentWithMultipleMessagesPerChannel()
+        {
+            // Arrange
+            var options = new AsyncApiOptions();
+            var schemaGenerator = new SchemaGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator(Options.Create(options), schemaGenerator);
+
+            // Act
+            var document = documentGenerator.GenerateDocument(new[]
+            {
+                typeof(TenantMessageConsumer).GetTypeInfo(),
+                typeof(TenantMessagePublisher).GetTypeInfo()
+            });
+
+            // Assert
+            document.ShouldNotBeNull();
+            document.Channels.Count.ShouldBe(1);
+
+            var channel = document.Channels.First();
+            channel.Key.ShouldBe("asw.tenant_service.tenants_history");
+            channel.Value.Description.ShouldBe("Tenant events.");
+
+            var subscribe = channel.Value.Subscribe;
+            subscribe.ShouldNotBeNull();
+            subscribe.OperationId.ShouldBe("TenantMessageConsumer");
+            subscribe.Summary.ShouldBe("Subscribe to domains events about tenants.");
+
+            var publish = channel.Value.Publish;
+            publish.ShouldNotBeNull();
+            publish.OperationId.ShouldBe("TenantMessagePublisher");
+            publish.Summary.ShouldBe("Publish domains events about tenants.");
+
+            var subscribeMessages = subscribe.Message.ShouldBeOfType<Messages>();
+            subscribeMessages.OneOf.Count.ShouldBe(3);
+
+            subscribeMessages.OneOf.ShouldContain(m => m.Name == "tenantCreated");
+            subscribeMessages.OneOf.ShouldContain(m => m.Name == "tenantUpdated");
+            subscribeMessages.OneOf.ShouldContain(m => m.Name == "tenantRemoved");
+
+            var publishMessages = subscribe.Message.ShouldBeOfType<Messages>();
+            publishMessages.OneOf.Count.ShouldBe(3);
+
+            publishMessages.OneOf.ShouldContain(m => m.Name == "tenantCreated");
+            publishMessages.OneOf.ShouldContain(m => m.Name == "tenantUpdated");
+            publishMessages.OneOf.ShouldContain(m => m.Name == "tenantRemoved");
         }
 
         [AsyncApi]
@@ -51,26 +99,52 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         public class TenantMessageConsumer : ITenantMessageConsumer
         {
             [Message(typeof(TenantCreated))]
-            public void SubscribeTenantCreatedEvent(Guid tenantId, TenantCreated evnt) {}
+            public void SubscribeTenantCreatedEvent(Guid tenantId, TenantCreated evnt) { }
 
             [Message(typeof(TenantUpdated))]
-            public void SubscribeTenantUpdatedEvent(Guid tenantId, TenantUpdated evnt) {}
+            public void SubscribeTenantUpdatedEvent(Guid tenantId, TenantUpdated evnt) { }
 
             [Message(typeof(TenantRemoved))]
-            public void SubscribeTenantRemovedEvent(Guid tenantId, TenantRemoved evnt) {}
+            public void SubscribeTenantRemovedEvent(Guid tenantId, TenantRemoved evnt) { }
+        }
+
+        [AsyncApi]
+        [Channel("asw.tenant_service.tenants_history", Description = "Tenant events.")]
+        [PublishOperation(OperationId = "TenantMessagePublisher", Summary = "Publish domains events about tenants.")]
+        public class TenantMessagePublisher : ITenantMessagePublisher
+        {
+            [Message(typeof(TenantCreated))]
+            public void PublishTenantCreatedEvent(Guid tenantId, TenantCreated evnt) { }
+
+            [Message(typeof(TenantUpdated))]
+            public void PublishTenantUpdatedEvent(Guid tenantId, TenantUpdated evnt) { }
+
+            [Message(typeof(TenantRemoved))]
+            public void PublishTenantRemovedEvent(Guid tenantId, TenantRemoved evnt) { }
         }
     }
-    
-    public class TenantCreated {}
-    
-    public class TenantUpdated {}
-    
-    public class TenantRemoved {}
-    
+
+    public class TenantCreated { }
+
+    public class TenantUpdated { }
+
+    public class TenantRemoved { }
+
     public interface ITenantMessageConsumer
     {
         void SubscribeTenantCreatedEvent(Guid tenantId, TenantCreated evnt);
+
         void SubscribeTenantUpdatedEvent(Guid tenantId, TenantUpdated evnt);
+
         void SubscribeTenantRemovedEvent(Guid tenantId, TenantRemoved evnt);
+    }
+
+    public interface ITenantMessagePublisher
+    {
+        void PublishTenantCreatedEvent(Guid tenantId, TenantCreated evnt);
+
+        void PublishTenantUpdatedEvent(Guid tenantId, TenantUpdated evnt);
+
+        void PublishTenantRemovedEvent(Guid tenantId, TenantRemoved evnt);
     }
 }


### PR DESCRIPTION
If a project tries to define Publish and Subscribe operations in different classes, with the nature of the `Channels` object as a form of `Dictionary<,>` the document generator will find a conflicting key in the dictionary when performing the second `Add` operation, making it impossible to do this.

With this change, a new `AddOrApped` operation enables a Publish/Subscribe operation to be added to an existing Channel key if the existing one didn't have one defined, while still failing if multiple Publish or Subscribe operations are found for the same Channel.