### PR TITLE
DictionaryKeyToStringConverter to support lists

### DIFF
--- a/src/Saunter/Utils/DictionaryKeyToStringConverter.cs
+++ b/src/Saunter/Utils/DictionaryKeyToStringConverter.cs
@@ -66,8 +66,7 @@ namespace Saunter.Utils
                 Type typeToConvert,
                 JsonSerializerOptions options)
             {
-                // Doesn't support deserialization
-                throw new NotSupportedException();
+                return (TType)_innerConverter.Read(ref reader, typeToConvert, options);
             }
 
             public override void Write(

--- a/src/Saunter/Utils/DictionaryKeyToStringConverter.cs
+++ b/src/Saunter/Utils/DictionaryKeyToStringConverter.cs
@@ -51,15 +51,14 @@ namespace Saunter.Utils
             return converter;
         }
 
-        private class InheritedDictionaryKeyToStringConverterInner<TType, TKey, TValue> : JsonConverter<TType> where TType : IDictionary<TKey, TValue>
+        private class InheritedDictionaryKeyToStringConverterInner<TType, TKey, TValue> :
+            JsonConverter<TType> where TType : IDictionary<TKey, TValue>
         {
-            private readonly JsonConverter<TValue> _valueConverter;
+            private readonly DictionaryKeyToStringConverterInner<TKey, TValue> _innerConverter;
 
             public InheritedDictionaryKeyToStringConverterInner(JsonSerializerOptions options)
             {
-                // For performance, use the existing converter if available.
-                _valueConverter = (JsonConverter<TValue>)options
-                    .GetConverter(typeof(TValue));
+                _innerConverter = new DictionaryKeyToStringConverterInner<TKey, TValue>(options);
             }
 
             public override TType Read(
@@ -76,19 +75,7 @@ namespace Saunter.Utils
                 TType dictionary,
                 JsonSerializerOptions options)
             {
-                writer.WriteStartObject();
-
-                foreach (KeyValuePair<TKey, TValue> kvp in dictionary)
-                {
-                    writer.WritePropertyName(kvp.Key.ToString());
-
-                    if (_valueConverter != null)
-                        _valueConverter.Write(writer, kvp.Value, options);
-                    else
-                        JsonSerializer.Serialize(writer, kvp.Value, options);
-                }
-
-                writer.WriteEndObject();
+                _innerConverter.Write(writer, dictionary, options);
             }
         }
 

--- a/test/Saunter.Tests/Utils/JsonConverterTests.cs
+++ b/test/Saunter.Tests/Utils/JsonConverterTests.cs
@@ -63,7 +63,31 @@ namespace Saunter.Tests.Utils
 
             data.ShouldBe("{\"test1\":null,\"test2\":null}");
         }
-        
+
+        [Fact]
+        public void DictionaryKeyToStringConverter_Convert_Should_OutputCorrectData_GivenClassExtendingDictionaryInList()
+        {
+            // Check whether serialization works
+            var list = new List<SecurityRequirement>
+            { 
+                new SecurityRequirement { 
+                    { "test1", new List<string>() { "testA", "testB" } },
+                    { "test2", new List<string>() {"testC" } }
+                }
+            };
+
+            var data = JsonSerializer.Serialize(
+                list,
+                new JsonSerializerOptions
+                {
+                    WriteIndented = false,
+                    Converters = { new DictionaryKeyToStringConverter() }
+                }
+            );
+
+            data.ShouldBe("[{\"test1\":[\"testA\",\"testB\"],\"test2\":[\"testC\"]}]");
+        }
+
 
         [Fact]
         public void InterfaceImplementationConverter_ShouldNot_ReturnEmptyObject()
@@ -88,5 +112,6 @@ namespace Saunter.Tests.Utils
             string actualValue = JsonSerializer.Serialize(value, value.GetType());
             actualValue.ShouldBe(expectedValue);
         }
+
     }
 }


### PR DESCRIPTION
Hopefully the test is self explanatory, but the DictionaryKeyToStringConverter ran into issues with passed Dictionary inherited classes in lists as it could not cast. More concretely, it was the SecurityRequirement class causing the issue

`    System.InvalidCastException : Unable to cast object of type DictionaryKeyToStringConverterInner[System.String,System.Collections.Generic.List1[System.String]] to type System.Text.Json.Serialization.JsonConverter[Saunter.AsyncApiSchema.v2.SecurityRequirement].
`