### PR TITLE
Multiple async api

### DIFF
--- a/src/Saunter/AsyncApiOptions.cs
+++ b/src/Saunter/AsyncApiOptions.cs
@@ -55,6 +55,8 @@ namespace Saunter
                 DefaultValueHandling = DefaultValueHandling.Ignore
             },
         };
+
+        public string ApiName { get; set; }
     }
 
     public class AsyncApiMiddlewareOptions

--- a/src/Saunter/AsyncApiOptions.cs
+++ b/src/Saunter/AsyncApiOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
@@ -42,6 +43,9 @@ namespace Saunter
         /// </summary>
         public AsyncApiMiddlewareOptions Middleware { get; } = new AsyncApiMiddlewareOptions();
 
+        public ConcurrentDictionary<string, AsyncApiDocument> NamedApis { get; set; } =
+            new ConcurrentDictionary<string, AsyncApiDocument>();
+
         /// <summary>
         /// Settings related to the JSON Schema generation.
         /// </summary>
@@ -55,8 +59,6 @@ namespace Saunter
                 DefaultValueHandling = DefaultValueHandling.Ignore
             },
         };
-
-        public string ApiName { get; set; }
     }
 
     public class AsyncApiMiddlewareOptions

--- a/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
+++ b/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
@@ -29,7 +29,7 @@ namespace Saunter.AsyncApiSchema.v2
         /// Provides connection details of servers.
         /// </summary>
         [JsonProperty("servers")]
-        public Dictionary<string, Server> Servers { get; } = new Dictionary<string, Server>();
+        public Dictionary<string, Server> Servers { get; set; } = new Dictionary<string, Server>();
 
         /// <summary>
         /// A string representing the default content type to use when encoding/decoding a message's payload.

--- a/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
+++ b/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
@@ -1,11 +1,13 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using NJsonSchema.Converters;
 
 namespace Saunter.AsyncApiSchema.v2
 {
     [JsonConverter(typeof(JsonReferenceConverter))]
-    public class AsyncApiDocument
+    public class AsyncApiDocument : ICloneable
     {
         /// <summary>
         /// Specifies the AsyncAPI Specification version being used.
@@ -73,6 +75,29 @@ namespace Saunter.AsyncApiSchema.v2
         public bool ShouldSerializeServers()
         {
             return Servers != null && Servers.Count > 0;
+        }
+
+        public AsyncApiDocument Clone()
+        {
+            var clone = new AsyncApiDocument();
+            clone.Info = Info;
+            clone.Id = Id;
+            clone.DefaultContentType = DefaultContentType;
+            clone.Channels = Channels.ToDictionary(p => p.Key, p => p.Value);
+            clone.Servers = Servers.ToDictionary(p => p.Key, p => p.Value);
+            foreach (var tag in Tags)
+            {
+                clone.Tags.Add(tag);
+            }
+            clone.ExternalDocs = ExternalDocs;
+            clone.Components = Components.Clone();
+
+            return clone;
+        }
+
+        object ICloneable.Clone()
+        {
+            return Clone();
         }
     }
 }

--- a/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
+++ b/src/Saunter/AsyncApiSchema/v2/AsyncApiDocument.cs
@@ -65,6 +65,8 @@ namespace Saunter.AsyncApiSchema.v2
         [JsonProperty("externalDocs", NullValueHandling = NullValueHandling.Ignore)]
         public ExternalDocumentation ExternalDocs { get; set; }
 
+        [JsonIgnore]
+        public string DocumentName { get; set; }
 
 
         public bool ShouldSerializeTags()

--- a/src/Saunter/AsyncApiSchema/v2/Components.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Components.cs
@@ -1,12 +1,14 @@
+using System;
 using NJsonSchema;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using Saunter.AsyncApiSchema.v2.Bindings;
 using Saunter.AsyncApiSchema.v2.Traits;
 
 namespace Saunter.AsyncApiSchema.v2
 {
-    public class Components
+    public class Components : ICloneable
     {
         /// <summary>
         /// An object to hold reusable Schema Objects.
@@ -130,6 +132,30 @@ namespace Saunter.AsyncApiSchema.v2
         public bool ShouldSerializeSchemas()
         {
             return Schemas != null && Schemas.Count > 0;
+        }
+
+        object ICloneable.Clone()
+        {
+            return Clone();
+        }
+
+        public Components Clone()
+        {
+            var clone = new Components();
+
+            clone.Schemas = Schemas.ToDictionary(p => p.Key, p => p.Value);
+            clone.Messages = Messages.ToDictionary(p => p.Key, p => p.Value);
+            clone.SecuritySchemes = SecuritySchemes.ToDictionary(p => p.Key, p => p.Value);
+            clone.Parameters = Parameters.ToDictionary(p => p.Key, p => p.Value);
+            clone.CorrelationIds = CorrelationIds.ToDictionary(p => p.Key, p => p.Value);
+            clone.ServerBindings = ServerBindings.ToDictionary(p => p.Key, p => p.Value);
+            clone.ChannelBindings = ChannelBindings.ToDictionary(p => p.Key, p => p.Value);
+            clone.OperationBindings = OperationBindings.ToDictionary(p => p.Key, p => p.Value);
+            clone.MessageBindings = MessageBindings.ToDictionary(p => p.Key, p => p.Value);
+            clone.OperationTraits = OperationTraits.ToDictionary(p => p.Key, p => p.Value);
+            clone.MessageTraits = MessageTraits.ToDictionary(p => p.Key, p => p.Value);
+
+            return clone;
         }
     }
 }

--- a/src/Saunter/AsyncApiSchema/v2/Parameter.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Parameter.cs
@@ -25,7 +25,7 @@ namespace Saunter.AsyncApiSchema.v2
         [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
-        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonIgnore]
         public string Name { get; set; }
         /// <summary>
         /// Definition of the parameter.

--- a/src/Saunter/AsyncApiSchema/v2/Parameter.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Parameter.cs
@@ -13,7 +13,14 @@ namespace Saunter.AsyncApiSchema.v2
     /// </summary>
     public class ParameterReference : Reference, IParameter
     {
-        public ParameterReference(string id) : base(id, "#/components/parameters/{0}") { }
+        private readonly AsyncApiDocument _document;
+        public ParameterReference(string id, AsyncApiDocument document) : base(id, "#/components/parameters/{0}")
+        {
+            _document = document;
+        }
+
+        [JsonIgnore]
+        public Parameter Value => _document.Components.Parameters[Id];
     }
     
     public class Parameter : IParameter

--- a/src/Saunter/AsyncApiSchema/v2/Server.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Server.cs
@@ -73,26 +73,26 @@ namespace Saunter.AsyncApiSchema.v2
         /// <summary>
         /// An enumeration of string values to be used if the substitution options are from a limited set.
         /// </summary>
-        [JsonProperty("enum")]
+        [JsonProperty("enum", NullValueHandling = NullValueHandling.Ignore)]
         public IList<string> Enum { get; set; }
 
         /// <summary>
         /// The default value to use for substitution, and to send, if an alternate value is not supplied.
         /// </summary>
-        [JsonProperty("default")]
+        [JsonProperty("default", NullValueHandling = NullValueHandling.Ignore)]
         public string Default { get; set; }
 
         /// <summary>
         /// An optional description for the server variable.
         /// CommonMark syntax MAY be used for rich text representation.
         /// </summary>
-        [JsonProperty("description")]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
         /// <summary>
         /// An array of examples of the server variable.
         /// </summary>
-        [JsonProperty("examples")]
+        [JsonProperty("examples", NullValueHandling = NullValueHandling.Ignore)]
         public IList<string> Examples { get; set; }
     }
 

--- a/src/Saunter/AsyncApiSchema/v2/Traits/OperationTrait.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Traits/OperationTrait.cs
@@ -26,38 +26,38 @@ namespace Saunter.AsyncApiSchema.v2.Traits
         /// Tools and libraries MAY use the operationId to uniquely identify an operation,
         /// therefore, it is RECOMMENDED to follow common programming naming conventions.
         /// </summary>
-        [JsonProperty("operationId")]
+        [JsonProperty("operationId", NullValueHandling = NullValueHandling.Ignore)]
         public string OperationId { get; set; }
 
         /// <summary>
         /// A short summary of what the operation is about.
         /// </summary>
-        [JsonProperty("summary")]
+        [JsonProperty("summary", NullValueHandling = NullValueHandling.Ignore)]
         public string Summary { get; set; }
 
         /// <summary>
         /// A verbose explanation of the operation.
         /// CommonMark syntax can be used for rich text representation.
         /// </summary>
-        [JsonProperty("description")]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
         /// <summary>
         /// A list of tags for API documentation control. Tags can be used for logical grouping of operations.
         /// </summary>
-        [JsonProperty("tags")]
+        [JsonProperty("tags", NullValueHandling = NullValueHandling.Ignore)]
         public ISet<Tag> Tags { get; set; }
 
         /// <summary>
         /// Additional external documentation for this operation.
         /// </summary>
-        [JsonProperty("externalDocs")]
+        [JsonProperty("externalDocs", NullValueHandling = NullValueHandling.Ignore)]
         public ExternalDocumentation ExternalDocs { get; set; }
 
         /// <summary>
         /// A free-form map where the keys describe the name of the protocol and the values describe protocol-specific definitions for the operation.
         /// </summary>
-        [JsonProperty("bindings")]
+        [JsonProperty("bindings", NullValueHandling = NullValueHandling.Ignore)]
         public IOperationBindings Bindings { get; set; }
     }
 }

--- a/src/Saunter/AsyncApiServiceCollectionExtensions.cs
+++ b/src/Saunter/AsyncApiServiceCollectionExtensions.cs
@@ -27,6 +27,8 @@ namespace Saunter
         {
             services.Configure<AsyncApiOptions>(options =>
             {
+                options.Middleware.Route = "/asyncapi/{document}/asyncapi.json";
+                options.Middleware.UiBaseRoute = "/asyncapi/{document}/ui/";
                 var document = options.NamedApis.GetOrAdd(documentName, _ => new AsyncApiDocument() {DocumentName = documentName});
 
                 setupAction(document);

--- a/src/Saunter/AsyncApiServiceCollectionExtensions.cs
+++ b/src/Saunter/AsyncApiServiceCollectionExtensions.cs
@@ -1,6 +1,7 @@
 using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Saunter.AsyncApiSchema.v2;
 using Saunter.Generation;
 using Saunter.Serialization;
 using Saunter.Utils;
@@ -22,9 +23,14 @@ namespace Saunter
             return services;
         }
 
-        public static IServiceCollection ConfigureNamedAsyncApi(this IServiceCollection services, string apiName, Action<AsyncApiOptions> setupAction)
+        public static IServiceCollection ConfigureNamedAsyncApi(this IServiceCollection services, string documentName, Action<AsyncApiDocument> setupAction)
         {
-            services.Configure(apiName, setupAction);
+            services.Configure<AsyncApiOptions>(options =>
+            {
+                var document = options.NamedApis.GetOrAdd(documentName, _ => new AsyncApiDocument() {DocumentName = documentName});
+
+                setupAction(document);
+            });
             return services;
         }
     }

--- a/src/Saunter/AsyncApiServiceCollectionExtensions.cs
+++ b/src/Saunter/AsyncApiServiceCollectionExtensions.cs
@@ -9,7 +9,7 @@ namespace Saunter
 {
     public static class AsyncApiServiceCollectionExtensions
     {
-        public static IServiceCollection AddAsyncApiSchemaGeneration(this IServiceCollection services, Action<AsyncApiOptions> setupAction)
+        public static IServiceCollection AddAsyncApiSchemaGeneration(this IServiceCollection services, Action<AsyncApiOptions> setupAction = null)
         {
             services.AddOptions();
 
@@ -19,6 +19,12 @@ namespace Saunter
 
             if (setupAction != null) services.Configure(setupAction);
 
+            return services;
+        }
+
+        public static IServiceCollection ConfigureNamedAsyncApi(this IServiceCollection services, string apiName, Action<AsyncApiOptions> setupAction)
+        {
+            services.Configure(apiName, setupAction);
             return services;
         }
     }

--- a/src/Saunter/Attributes/AsyncApiAttribute.cs
+++ b/src/Saunter/Attributes/AsyncApiAttribute.cs
@@ -8,12 +8,11 @@ namespace Saunter.Attributes
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class AsyncApiAttribute : Attribute
     {
-        public string ApiName { get; }
-
-        // Just a marker.
-        public AsyncApiAttribute(string apiName = null)
+        public string DocumentName { get; }
+        
+        public AsyncApiAttribute(string documentName = null)
         {
-            ApiName = apiName;
+            DocumentName = documentName;
         }
     }
 }

--- a/src/Saunter/Attributes/AsyncApiAttribute.cs
+++ b/src/Saunter/Attributes/AsyncApiAttribute.cs
@@ -8,6 +8,12 @@ namespace Saunter.Attributes
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class AsyncApiAttribute : Attribute
     {
-        // Just a marker.   
+        public string ApiName { get; }
+
+        // Just a marker.
+        public AsyncApiAttribute(string apiName = null)
+        {
+            ApiName = apiName;
+        }
     }
 }

--- a/src/Saunter/Generation/AsyncApiDocumentProvider.cs
+++ b/src/Saunter/Generation/AsyncApiDocumentProvider.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Reflection;
 using Saunter.AsyncApiSchema.v2;
 using Saunter.Attributes;
-using Saunter.Utils;
 
 namespace Saunter.Generation
 {
@@ -16,29 +15,29 @@ namespace Saunter.Generation
             _documentGenerator = documentGenerator;
         }
 
-        public AsyncApiDocument GetDocument(AsyncApiOptions options)
+        public AsyncApiDocument GetDocument(AsyncApiOptions options, AsyncApiDocument prototype)
         {
             if (options == null)
             {
                 throw new ArgumentNullException(nameof(options));
             }
-            var asyncApiTypes = GetAsyncApiTypes(options);
+            var asyncApiTypes = GetAsyncApiTypes(options, prototype);
 
-            var document = _documentGenerator.GenerateDocument(asyncApiTypes, options);
+            var document = _documentGenerator.GenerateDocument(asyncApiTypes, options, prototype);
 
             return document;
         }
-        
-        
+
+
         /// <summary>
-        /// Get all types with an <see cref="AsyncApiAttribute"/> from assemblies contAsyncApiOptionsef="SaunterOptions.AssemblyMarkerTypes"/>.
+        /// Get all types with an <see cref="AsyncApiAttribute"/> from assemblies <see cref="AsyncApiOptions.AssemblyMarkerTypes"/>.
         /// </summary>
-        private TypeInfo[] GetAsyncApiTypes(AsyncApiOptions options)
+        private static TypeInfo[] GetAsyncApiTypes(AsyncApiOptions options, AsyncApiDocument prototype)
         {
             var assembliesToScan = options.AssemblyMarkerTypes.Select(t => t.Assembly);
 
             var asyncApiTypes = assembliesToScan
-                .SelectMany(a => a.DefinedTypes.Where(t => t.GetCustomAttribute<AsyncApiAttribute>()?.ApiName == options.ApiName))
+                .SelectMany(a => a.DefinedTypes.Where(t => t.GetCustomAttribute<AsyncApiAttribute>()?.DocumentName == prototype.DocumentName))
                 .ToArray();
 
             return asyncApiTypes;

--- a/src/Saunter/Generation/AsyncApiDocumentProvider.cs
+++ b/src/Saunter/Generation/AsyncApiDocumentProvider.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.Options;
 using Saunter.AsyncApiSchema.v2;
 using Saunter.Attributes;
 using Saunter.Utils;
@@ -11,20 +10,21 @@ namespace Saunter.Generation
     public class AsyncApiDocumentProvider : IAsyncApiDocumentProvider
     {
         private readonly IDocumentGenerator _documentGenerator;
-        private readonly AsyncApiOptions _options;
 
-        public AsyncApiDocumentProvider(IOptions<AsyncApiOptions> options, IDocumentGenerator documentGenerator)
+        public AsyncApiDocumentProvider(IDocumentGenerator documentGenerator)
         {
             _documentGenerator = documentGenerator;
-            _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         }
-        
-        
-        public AsyncApiDocument GetDocument()
-        {
-            var asyncApiTypes = GetAsyncApiTypes();
 
-            var document = _documentGenerator.GenerateDocument(asyncApiTypes);
+        public AsyncApiDocument GetDocument(AsyncApiOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            var asyncApiTypes = GetAsyncApiTypes(options);
+
+            var document = _documentGenerator.GenerateDocument(asyncApiTypes, options);
 
             return document;
         }
@@ -33,12 +33,12 @@ namespace Saunter.Generation
         /// <summary>
         /// Get all types with an <see cref="AsyncApiAttribute"/> from assemblies contAsyncApiOptionsef="SaunterOptions.AssemblyMarkerTypes"/>.
         /// </summary>
-        private TypeInfo[] GetAsyncApiTypes()
+        private TypeInfo[] GetAsyncApiTypes(AsyncApiOptions options)
         {
-            var assembliesToScan = _options.AssemblyMarkerTypes.Select(t => t.Assembly);
+            var assembliesToScan = options.AssemblyMarkerTypes.Select(t => t.Assembly);
 
             var asyncApiTypes = assembliesToScan
-                .SelectMany(a => a.DefinedTypes.Where(t => t.HasCustomAttribute<AsyncApiAttribute>()))
+                .SelectMany(a => a.DefinedTypes.Where(t => t.GetCustomAttribute<AsyncApiAttribute>()?.ApiName == options.ApiName))
                 .ToArray();
 
             return asyncApiTypes;

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -20,9 +20,9 @@ namespace Saunter.Generation
         {
         }
 
-        public AsyncApiSchema.v2.AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options)
+        public AsyncApiSchema.v2.AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options, AsyncApiDocument prototype)
         {
-            var asyncApiSchema = options.AsyncApi.Clone();
+            var asyncApiSchema = prototype.Clone();
 
             var schemaResolver = new AsyncApiSchemaResolver(asyncApiSchema, options.JsonSchemaGeneratorSettings);
 
@@ -41,7 +41,7 @@ namespace Saunter.Generation
         /// <summary>
         /// Generate the Channels section of an AsyncApi schema.
         /// </summary>
-        private IDictionary<string, ChannelItem> GenerateChannels(TypeInfo[] asyncApiTypes, AsyncApiSchemaResolver schemaResolver, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IDictionary<string, ChannelItem> GenerateChannels(TypeInfo[] asyncApiTypes, AsyncApiSchemaResolver schemaResolver, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
         {
             var channels = new Dictionary<string, ChannelItem>();
             
@@ -54,7 +54,7 @@ namespace Saunter.Generation
         /// Generate the Channels section of the AsyncApi schema from the
         /// <see cref="ChannelAttribute"/> on methods.
         /// </summary>
-        private IDictionary<string, ChannelItem> GenerateChannelsFromMethods(IEnumerable<TypeInfo> asyncApiTypes, AsyncApiSchemaResolver schemaResolver, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IDictionary<string, ChannelItem> GenerateChannelsFromMethods(IEnumerable<TypeInfo> asyncApiTypes, AsyncApiSchemaResolver schemaResolver, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
         {
             var channels = new Dictionary<string, ChannelItem>();
 
@@ -93,7 +93,7 @@ namespace Saunter.Generation
         /// Generate the Channels section of the AsyncApi schema from the
         /// <see cref="ChannelAttribute"/> on classes.
         /// </summary>
-        private IDictionary<string, ChannelItem> GenerateChannelsFromClasses(IEnumerable<TypeInfo> asyncApiTypes, AsyncApiSchemaResolver schemaResolver, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IDictionary<string, ChannelItem> GenerateChannelsFromClasses(IEnumerable<TypeInfo> asyncApiTypes, AsyncApiSchemaResolver schemaResolver, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
         {
             var channels = new Dictionary<string, ChannelItem>();
 
@@ -131,7 +131,7 @@ namespace Saunter.Generation
         /// <summary>
         /// Generate the an operation of an AsyncApi Channel for the given method.
         /// </summary>
-        private Operation GenerateOperationFromMethod(MethodInfo method, AsyncApiSchemaResolver schemaResolver, OperationType operationType, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
+        private static Operation GenerateOperationFromMethod(MethodInfo method, AsyncApiSchemaResolver schemaResolver, OperationType operationType, AsyncApiOptions options, JsonSchemaGenerator jsonSchemaGenerator)
         {
             var operationAttribute = GetOperationAttribute(method, operationType);
             if (operationAttribute == null)
@@ -165,7 +165,7 @@ namespace Saunter.Generation
         /// <summary>
         /// Generate the an operation of an AsyncApi Channel for the given class.
         /// </summary>
-        private Operation GenerateOperationFromClass(TypeInfo type, AsyncApiSchemaResolver schemaResolver, OperationType operationType, JsonSchemaGenerator jsonSchemaGenerator)
+        private static Operation GenerateOperationFromClass(TypeInfo type, AsyncApiSchemaResolver schemaResolver, OperationType operationType, JsonSchemaGenerator jsonSchemaGenerator)
         {
             var operationAttribute = GetOperationAttribute(type, operationType);
             if (operationAttribute == null)
@@ -225,7 +225,7 @@ namespace Saunter.Generation
             }
         }
 
-        private IMessage GenerateMessageFromAttributes(IEnumerable<MessageAttribute> messageAttributes, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IMessage GenerateMessageFromAttributes(IEnumerable<MessageAttribute> messageAttributes, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
         {
             if (messageAttributes.Count() == 1)
             {
@@ -250,7 +250,7 @@ namespace Saunter.Generation
             return messages;
         }
 
-        private IMessage GenerateMessageFromAttribute(MessageAttribute messageAttribute, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IMessage GenerateMessageFromAttribute(MessageAttribute messageAttribute, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
         {
             if (messageAttribute?.PayloadType == null)
             {
@@ -271,7 +271,7 @@ namespace Saunter.Generation
         }
         
 
-        private IMessage GenerateMessageFromType(Type payloadType, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IMessage GenerateMessageFromType(Type payloadType, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
         {
             if (payloadType == null)
             {
@@ -287,7 +287,7 @@ namespace Saunter.Generation
             return schemaResolver.GetMessageOrReference(message);
         }
 
-        private IDictionary<string,IParameter> GetChannelParametersFromAttributes(MemberInfo memberInfo, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
+        private static IDictionary<string,IParameter> GetChannelParametersFromAttributes(MemberInfo memberInfo, AsyncApiSchemaResolver schemaResolver, JsonSchemaGenerator jsonSchemaGenerator)
         {
             IEnumerable<ChannelParameterAttribute> attributes = memberInfo.GetCustomAttributes<ChannelParameterAttribute>();
             var parameters = new Dictionary<string, IParameter>();

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -22,29 +22,7 @@ namespace Saunter.Generation
 
         public AsyncApiSchema.v2.AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options)
         {
-            // todo: clone the global document so each call generates a new document
-            var asyncApiSchema = new AsyncApiDocument();
-            asyncApiSchema.Info = options.AsyncApi.Info;
-            asyncApiSchema.Id = options.AsyncApi.Id;
-            asyncApiSchema.DefaultContentType = options.AsyncApi.DefaultContentType;
-            asyncApiSchema.Channels = options.AsyncApi.Channels.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Servers = options.AsyncApi.Servers.ToDictionary(p => p.Key, p => p.Value);
-            foreach (var tag in options.AsyncApi.Tags)
-            {
-                asyncApiSchema.Tags.Add(tag);
-            }
-            asyncApiSchema.ExternalDocs = options.AsyncApi.ExternalDocs;
-            asyncApiSchema.Components.Schemas = options.AsyncApi.Components.Schemas.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.Messages = options.AsyncApi.Components.Messages.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.SecuritySchemes = options.AsyncApi.Components.SecuritySchemes.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.Parameters = options.AsyncApi.Components.Parameters.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.CorrelationIds = options.AsyncApi.Components.CorrelationIds.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.ServerBindings = options.AsyncApi.Components.ServerBindings.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.ChannelBindings = options.AsyncApi.Components.ChannelBindings.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.OperationBindings = options.AsyncApi.Components.OperationBindings.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.MessageBindings = options.AsyncApi.Components.MessageBindings.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.OperationTraits = options.AsyncApi.Components.OperationTraits.ToDictionary(p => p.Key, p => p.Value);
-            asyncApiSchema.Components.MessageTraits = options.AsyncApi.Components.MessageTraits.ToDictionary(p => p.Key, p => p.Value);
+            var asyncApiSchema = options.AsyncApi.Clone();
 
             var schemaResolver = new AsyncApiSchemaResolver(asyncApiSchema, options.JsonSchemaGeneratorSettings);
 

--- a/src/Saunter/Generation/IDocumentGenerator.cs
+++ b/src/Saunter/Generation/IDocumentGenerator.cs
@@ -5,6 +5,6 @@ namespace Saunter.Generation
 {
     public interface IDocumentGenerator
     {
-        AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options);
+        AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options, AsyncApiDocument prototype);
     }
 }

--- a/src/Saunter/Generation/IDocumentGenerator.cs
+++ b/src/Saunter/Generation/IDocumentGenerator.cs
@@ -5,6 +5,6 @@ namespace Saunter.Generation
 {
     public interface IDocumentGenerator
     {
-        AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes);
+        AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options);
     }
 }

--- a/src/Saunter/Generation/SchemaGeneration/AsyncApiSchemaResolver.cs
+++ b/src/Saunter/Generation/SchemaGeneration/AsyncApiSchemaResolver.cs
@@ -58,5 +58,21 @@ namespace Saunter.Generation.SchemaGeneration
 
             return new MessageReference(id);
         }
+
+        public IParameter GetParameterOrReference(Parameter parameter)
+        {
+            var id = parameter.Name;
+            if (id == null)
+            {
+                return parameter;
+            }
+
+            if (!_document.Components.Parameters.ContainsKey(id))
+            {
+                _document.Components.Parameters.Add(id, parameter);
+            }
+
+            return new ParameterReference(id);
+        }
     }
 }

--- a/src/Saunter/Generation/SchemaGeneration/AsyncApiSchemaResolver.cs
+++ b/src/Saunter/Generation/SchemaGeneration/AsyncApiSchemaResolver.cs
@@ -72,7 +72,7 @@ namespace Saunter.Generation.SchemaGeneration
                 _document.Components.Parameters.Add(id, parameter);
             }
 
-            return new ParameterReference(id);
+            return new ParameterReference(id, _document);
         }
     }
 }

--- a/src/Saunter/IAsyncApiDocumentProvider.cs
+++ b/src/Saunter/IAsyncApiDocumentProvider.cs
@@ -4,6 +4,6 @@ namespace Saunter
 {
     public interface IAsyncApiDocumentProvider
     {
-        AsyncApiDocument GetDocument();
+        AsyncApiDocument GetDocument(AsyncApiOptions options);
     }
 }

--- a/src/Saunter/IAsyncApiDocumentProvider.cs
+++ b/src/Saunter/IAsyncApiDocumentProvider.cs
@@ -4,6 +4,6 @@ namespace Saunter
 {
     public interface IAsyncApiDocumentProvider
     {
-        AsyncApiDocument GetDocument(AsyncApiOptions options);
+        AsyncApiDocument GetDocument(AsyncApiOptions options, AsyncApiDocument prototype);
     }
 }

--- a/src/Saunter/Saunter.csproj
+++ b/src/Saunter/Saunter.csproj
@@ -25,12 +25,13 @@
 
   <ItemGroup>
     <Compile Remove="UI\node_modules\**" />
-    <EmbeddedResource Remove="UI\node_modules\**" />
     <None Remove="UI\node_modules\**" />
   </ItemGroup>
 
   <ItemGroup>
     <EmbeddedResource Include="UI/index.html" />
+    <EmbeddedResource Include="UI/node_modules/@asyncapi/react-component/browser/standalone/index.js" LogicalName="Saunter.UI.index.js" Condition="Exists('UI/node_modules')" />
+    <EmbeddedResource Include="UI/node_modules/@asyncapi/react-component/styles/default.min.css" LogicalName="Saunter.UI.default.min.css" Condition="Exists('UI/node_modules')" />
   </ItemGroup>
 
   <Target Name="NpmInstall" BeforeTargets="Build" Inputs="UI/package.json" Outputs="UI/node_modules/.install-stamp">

--- a/src/Saunter/Saunter.csproj
+++ b/src/Saunter/Saunter.csproj
@@ -56,4 +56,12 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+        <PackageReference Include="Microsoft.AspnetCore.Http" Version="2.0.0" />
+        <PackageReference Include="Microsoft.AspnetCore.StaticFiles" Version="2.0.0" />
+        <PackageReference Include="Microsoft.AspnetCore.Hosting" Version="2.0.0" />
+        <PackageReference Include="Microsoft.AspnetCore.Routing" Version="2.0.0" />
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="2.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/Saunter/Saunter.csproj
+++ b/src/Saunter/Saunter.csproj
@@ -24,9 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="UI\node_modules\**" />
+    <EmbeddedResource Remove="UI\node_modules\**" />
+    <None Remove="UI\node_modules\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <EmbeddedResource Include="UI/index.html" />
-    <EmbeddedResource Include="UI/node_modules/@asyncapi/react-component/browser/standalone/index.js" LogicalName="Saunter.UI.index.js" Condition="Exists('UI/node_modules')" />
-    <EmbeddedResource Include="UI/node_modules/@asyncapi/react-component/styles/default.min.css" LogicalName="Saunter.UI.default.min.css" Condition="Exists('UI/node_modules')" />
   </ItemGroup>
 
   <Target Name="NpmInstall" BeforeTargets="Build" Inputs="UI/package.json" Outputs="UI/node_modules/.install-stamp">

--- a/src/Saunter/Serialization/IAsyncApiDocumentSerializer.cs
+++ b/src/Saunter/Serialization/IAsyncApiDocumentSerializer.cs
@@ -6,6 +6,6 @@ namespace Saunter.Serialization
     {
         string ContentType { get; }
 
-        string Serialize(AsyncApiDocument document);
+        string Serialize(AsyncApiDocument document, AsyncApiOptions options);
     }
 }

--- a/src/Saunter/Serialization/NewtonsoftAsyncApiDocumentSerializer.cs
+++ b/src/Saunter/Serialization/NewtonsoftAsyncApiDocumentSerializer.cs
@@ -6,17 +6,14 @@ namespace Saunter.Serialization
 {
     public class NewtonsoftAsyncApiDocumentSerializer : IAsyncApiDocumentSerializer
     {
-        private readonly IOptions<AsyncApiOptions> _options;
-
-        public NewtonsoftAsyncApiDocumentSerializer(IOptions<AsyncApiOptions> options)
+        public NewtonsoftAsyncApiDocumentSerializer()
         {
-            _options = options;
         }
 
         public string ContentType => "application/json";
-        public string Serialize(AsyncApiDocument document)
+        public string Serialize(AsyncApiDocument document, AsyncApiOptions options)
         {
-            return JsonConvert.SerializeObject(document, _options.Value.JsonSchemaGeneratorSettings.ActualSerializerSettings);
+            return JsonConvert.SerializeObject(document, options.JsonSchemaGeneratorSettings.ActualSerializerSettings);
         }
     }
 }

--- a/src/Saunter/UI/AsyncApiUiMiddleware.cs
+++ b/src/Saunter/UI/AsyncApiUiMiddleware.cs
@@ -1,3 +1,5 @@
+#if !NETSTANDARD2_0
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,11 +22,8 @@ namespace Saunter.UI
         private readonly AsyncApiOptions _options;
         private readonly StaticFileMiddleware _staticFiles;
 
-#if NETSTANDARD2_0
-        public AsyncApiUiMiddleware(RequestDelegate next, IOptionsSnapshot<AsyncApiOptions> options, IHostingEnvironment env, ILoggerFactory loggerFactory, string apiName = null)
-#else
+
         public AsyncApiUiMiddleware(RequestDelegate next, IOptionsSnapshot<AsyncApiOptions> options, IWebHostEnvironment env, ILoggerFactory loggerFactory, string apiName = null)
-#endif
         {
             if (apiName == null)
             {
@@ -105,3 +104,4 @@ namespace Saunter.UI
         private string UiBaseRoute => _options.Middleware.UiBaseRoute?.TrimEnd('/') ?? string.Empty;
     }
 }
+#endif

--- a/src/Saunter/UI/AsyncApiUiMiddleware.cs
+++ b/src/Saunter/UI/AsyncApiUiMiddleware.cs
@@ -72,7 +72,7 @@ namespace Saunter.UI
             {
                 if (context.TryGetDocument(_options, out var document))
                 {
-                    await RespondWithAsyncApiHtml(context.Response, "/" + _options.Middleware.Route.Replace("{document}", document));
+                    await RespondWithAsyncApiHtml(context.Response, _options.Middleware.Route.Replace("{document}", document));
                 }
                 else
                 {

--- a/src/Saunter/UI/AsyncApiUiMiddleware.cs
+++ b/src/Saunter/UI/AsyncApiUiMiddleware.cs
@@ -64,8 +64,6 @@ namespace Saunter.UI
         {
             await using var stream = GetType().Assembly.GetManifestResourceStream($"{GetType().Namespace}.index.html");
             using var reader = new StreamReader(stream);
-
-
             var indexHtml = new StringBuilder(await reader.ReadToEndAsync());
 
             // Replace dynamic content such as the AsyncAPI document url
@@ -74,7 +72,7 @@ namespace Saunter.UI
                 indexHtml.Replace(replacement.Key, replacement.Value);
             }
 
-            response.StatusCode = (int) HttpStatusCode.OK;
+            response.StatusCode = (int)HttpStatusCode.OK;
             response.ContentType = MediaTypeNames.Text.Html;
             await response.WriteAsync(indexHtml.ToString(), Encoding.UTF8);
         }

--- a/src/Saunter/UI/AsyncApiUiMiddleware.cs
+++ b/src/Saunter/UI/AsyncApiUiMiddleware.cs
@@ -1,5 +1,3 @@
-#if !NETSTANDARD2_0
-
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -10,6 +8,8 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Logging;
@@ -21,25 +21,32 @@ namespace Saunter.UI
     {
         private readonly AsyncApiOptions _options;
         private readonly StaticFileMiddleware _staticFiles;
+        private readonly Dictionary<string, StaticFileMiddleware> _namedStaticFiles;
 
-
-        public AsyncApiUiMiddleware(RequestDelegate next, IOptionsSnapshot<AsyncApiOptions> options, IWebHostEnvironment env, ILoggerFactory loggerFactory, string apiName = null)
+#if NETSTANDARD2_0
+        public AsyncApiUiMiddleware(RequestDelegate next, IOptions<AsyncApiOptions> options, IHostingEnvironment env, ILoggerFactory loggerFactory)
+#else
+        public AsyncApiUiMiddleware(RequestDelegate next, IOptions<AsyncApiOptions> options, IWebHostEnvironment env, ILoggerFactory loggerFactory)
+#endif
         {
-            if (apiName == null)
-            {
-                _options = options.Value;
-            }
-            else
-            {
-                _options = options.Get(apiName);
-            }
-
+            _options = options.Value;
             var staticFileOptions = new StaticFileOptions
             {
                 RequestPath = UiBaseRoute,
                 FileProvider = new EmbeddedFileProvider(GetType().Assembly, GetType().Namespace),
             };
             _staticFiles = new StaticFileMiddleware(next, env, Options.Create(staticFileOptions), loggerFactory);
+            _namedStaticFiles = new Dictionary<string, StaticFileMiddleware>();
+
+            foreach (var namedApi in _options.NamedApis)
+            {
+                var namedStaticFileOptions = new StaticFileOptions
+                {
+                    RequestPath = UiBaseRoute.Replace("{document}", namedApi.Key),
+                    FileProvider = new EmbeddedFileProvider(GetType().Assembly, GetType().Namespace),
+                };
+                _namedStaticFiles.Add(namedApi.Key, new StaticFileMiddleware(next, env, Options.Create(namedStaticFileOptions), loggerFactory));
+            }
         }
 
         public async Task Invoke(HttpContext context)
@@ -51,30 +58,69 @@ namespace Saunter.UI
                 return;
             }
 
+            {
+                if (IsRequestingNamedUiBase(context.Request, out var document))
+                {
+                    context.Response.StatusCode = (int)HttpStatusCode.MovedPermanently;
+                    context.Response.Headers["Location"] = UiIndexRoute.Replace("{document}", document);
+                    return;
+                }
+            }
+
             if (IsRequestingAsyncApiUi(context.Request))
             {
-                await RespondWithAsyncApiHtml(context.Response);
+                await RespondWithAsyncApiHtml(context.Response, _options.Middleware.Route);
                 return;
             }
 
-            await _staticFiles.Invoke(context);
-        }
-
-        private async Task RespondWithAsyncApiHtml(HttpResponse response)
-        {
-            await using var stream = GetType().Assembly.GetManifestResourceStream($"{GetType().Namespace}.index.html");
-            using var reader = new StreamReader(stream);
-            var indexHtml = new StringBuilder(await reader.ReadToEndAsync());
-
-            // Replace dynamic content such as the AsyncAPI document url
-            foreach (var replacement in IndexHtmlReplacements)
             {
-                indexHtml.Replace(replacement.Key, replacement.Value);
+
+                if (IsRequestingNamedAsyncApiUi(context.Request, out var document))
+                {
+                    await RespondWithAsyncApiHtml(context.Response, "/" + _options.Middleware.Route.Replace("{document}", document));
+                    return;
+                }
             }
 
-            response.StatusCode = (int)HttpStatusCode.OK;
-            response.ContentType = MediaTypeNames.Text.Html;
-            await response.WriteAsync(indexHtml.ToString(), Encoding.UTF8);
+            var documentName = GetDocumentName(context.Request);
+            if (documentName == null)
+            {
+                await _staticFiles.Invoke(context);
+            }
+            else
+            {
+                if (_namedStaticFiles.TryGetValue(documentName, out var files))
+                {
+                    await files.Invoke(context);
+                }
+                else
+                {
+                    await _staticFiles.Invoke(context);
+                }
+            }
+        }
+
+        private async Task RespondWithAsyncApiHtml(HttpResponse response, string route)
+        {
+            using (var stream = GetType().Assembly.GetManifestResourceStream($"{GetType().Namespace}.index.html"))
+            using (var reader = new StreamReader(stream))
+            {
+                var indexHtml = new StringBuilder(await reader.ReadToEndAsync());
+
+                // Replace dynamic content such as the AsyncAPI document url
+                foreach (var replacement in new Dictionary<string, string>
+                {
+                    ["{{title}}"] = _options.Middleware.UiTitle,
+                    ["{{asyncApiDocumentUrl}}"] = route,
+                })
+                {
+                    indexHtml.Replace(replacement.Key, replacement.Value);
+                }
+
+                response.StatusCode = (int)HttpStatusCode.OK;
+                response.ContentType = MediaTypeNames.Text.Html;
+                await response.WriteAsync(indexHtml.ToString(), Encoding.UTF8);
+            }
         }
 
         private bool IsRequestingUiBase(HttpRequest request)
@@ -82,23 +128,66 @@ namespace Saunter.UI
             return HttpMethods.IsGet(request.Method)
                    && string.Equals(request.Path.Value?.TrimEnd('/'), UiBaseRoute, StringComparison.OrdinalIgnoreCase);
         }
-        
+
+        private bool IsRequestingNamedUiBase(HttpRequest request, out string documentName)
+        {
+            var template = TemplateParser.Parse(UiBaseRoute);
+
+            var values = new RouteValueDictionary();
+            var matcher = new TemplateMatcher(template, values);
+
+            documentName = null;
+            var matching = matcher.TryMatch(request.Path, values);
+            if (values.TryGetValue("document", out var temp))
+            {
+                documentName = temp.ToString();
+            }
+
+            return HttpMethods.IsGet(request.Method) && matching;
+        }
+
+        private string GetDocumentName(HttpRequest request)
+        {
+            var template = TemplateParser.Parse(_options.Middleware.UiBaseRoute + "{*wildcard}");
+            var values = new RouteValueDictionary();
+            var matcher = new TemplateMatcher(template, values);
+
+            string documentName = null;
+            var matching = matcher.TryMatch(request.Path, values);
+            if (values.TryGetValue("document", out var temp))
+            {
+                documentName = temp.ToString();
+            }
+
+            return documentName;
+        }
+
         private bool IsRequestingAsyncApiUi(HttpRequest request)
         {
             return HttpMethods.IsGet(request.Method)
                    && string.Equals(request.Path, UiIndexRoute, StringComparison.OrdinalIgnoreCase);
         }
 
-        private Dictionary<string, string> IndexHtmlReplacements
-            => new Dictionary<string, string>
+
+        private bool IsRequestingNamedAsyncApiUi(HttpRequest request, out string documentName)
+        {
+            var template = TemplateParser.Parse(UiIndexRoute);
+
+            var values = new RouteValueDictionary();
+            var matcher = new TemplateMatcher(template, values);
+
+            documentName = null;
+            var matching = matcher.TryMatch(request.Path, values);
+            if (values.TryGetValue("document", out var temp))
             {
-                ["{{title}}"] = _options.Middleware.UiTitle,
-                ["{{asyncApiDocumentUrl}}"] = _options.Middleware.Route,
-            };
+                documentName = temp.ToString();
+            }
+
+            return HttpMethods.IsGet(request.Method) && matching;
+        }
 
         private string UiIndexRoute => _options.Middleware.UiBaseRoute?.TrimEnd('/') + "/index.html";
 
         private string UiBaseRoute => _options.Middleware.UiBaseRoute?.TrimEnd('/') ?? string.Empty;
     }
 }
-#endif

--- a/src/Saunter/UI/AsyncApiUiMiddleware.cs
+++ b/src/Saunter/UI/AsyncApiUiMiddleware.cs
@@ -62,23 +62,22 @@ namespace Saunter.UI
 
         private async Task RespondWithAsyncApiHtml(HttpResponse response)
         {
-            using (var stream = GetType().Assembly.GetManifestResourceStream($"{GetType().Namespace}.index.html"))
-            using (var reader = new StreamReader(stream))
+            await using var stream = GetType().Assembly.GetManifestResourceStream($"{GetType().Namespace}.index.html");
+            using var reader = new StreamReader(stream);
+
+
+            var indexHtml = new StringBuilder(await reader.ReadToEndAsync());
+
+            // Replace dynamic content such as the AsyncAPI document url
+            foreach (var replacement in IndexHtmlReplacements)
             {
-                var indexHtml = new StringBuilder(await reader.ReadToEndAsync());
-
-                // Replace dynamic content such as the AsyncAPI document url
-                foreach (var replacement in IndexHtmlReplacements)
-                {
-                    indexHtml.Replace(replacement.Key, replacement.Value);
-                }
-
-                response.StatusCode = (int)HttpStatusCode.OK;
-                response.ContentType = MediaTypeNames.Text.Html;
-                await response.WriteAsync(indexHtml.ToString(), Encoding.UTF8);
+                indexHtml.Replace(replacement.Key, replacement.Value);
             }
-        }
 
+            response.StatusCode = (int) HttpStatusCode.OK;
+            response.ContentType = MediaTypeNames.Text.Html;
+            await response.WriteAsync(indexHtml.ToString(), Encoding.UTF8);
+        }
 
         private bool IsRequestingUiBase(HttpRequest request)
         {

--- a/src/Saunter/Utils/RouteMatchingExtensions.cs
+++ b/src/Saunter/Utils/RouteMatchingExtensions.cs
@@ -23,7 +23,12 @@ namespace Saunter.Utils
 
             var values = new RouteValueDictionary();
             var matcher = new TemplateMatcher(template, values);
-            matcher.TryMatch(context.Request.Path, values);
+            if (!matcher.TryMatch(context.Request.Path, values))
+            {
+                template = TemplateParser.Parse(options.Middleware.UiBaseRoute + "{*wildcard}"); 
+                matcher = new TemplateMatcher(template, values);
+                matcher.TryMatch(context.Request.Path, values);
+            }
 #else
             var values = context.Request.RouteValues;
 #endif

--- a/src/Saunter/Utils/RouteMatchingExtensions.cs
+++ b/src/Saunter/Utils/RouteMatchingExtensions.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.Routing.Template;
+
+namespace Saunter.Utils
+{
+    public static class RouteMatchingExtensions
+    {
+        public static bool IsMatchingRoute(this PathString path, string pattern)
+        {
+            var template = TemplateParser.Parse(pattern);
+
+            var values = new RouteValueDictionary();
+            var matcher = new TemplateMatcher(template, values);
+            return matcher.TryMatch(path, values);
+        }
+
+        public static bool TryGetDocument(this HttpContext context, AsyncApiOptions options, out string document)
+        {
+            document = null;
+#if NETSTANDARD2_0
+            var template = TemplateParser.Parse(options.Middleware.Route);
+
+            var values = new RouteValueDictionary();
+            var matcher = new TemplateMatcher(template, values);
+            matcher.TryMatch(context.Request.Path, values);
+#else
+            var values = context.Request.RouteValues;
+#endif
+            if (!values.TryGetValue("document", out var value))
+            {
+                return false;
+            }
+
+            document = value.ToString();
+            return true;
+        }
+    }
+}

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
@@ -19,10 +19,10 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         {
             // Arrange
             var options = new AsyncApiOptions();
-            var documentGenerator = new DocumentGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator();
             
             // Act
-            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() });
+            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() }, options);
 
             // Assert
             document.ShouldNotBeNull();
@@ -51,10 +51,10 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         {
             // Arrange
             var options = new AsyncApiOptions();
-            var documentGenerator = new DocumentGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantGenericMessagePublisher).GetTypeInfo() });
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantGenericMessagePublisher).GetTypeInfo() }, options);
 
             // Assert
             document.ShouldNotBeNull();
@@ -83,10 +83,10 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         {
             // Arrange
             var options = new AsyncApiOptions();
-            var documentGenerator = new DocumentGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantSingleMessagePublisher).GetTypeInfo() });
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantSingleMessagePublisher).GetTypeInfo() }, options);
 
             // Assert
             document.ShouldNotBeNull();
@@ -111,14 +111,14 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         {
             // Arrange
             var options = new AsyncApiOptions();
-            var documentGenerator = new DocumentGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator();
 
             // Act
             var document = documentGenerator.GenerateDocument(new[]
             {
                 typeof(TenantMessageConsumer).GetTypeInfo(),
                 typeof(TenantMessagePublisher).GetTypeInfo()
-            });
+            }, options);
 
             // Assert
             document.ShouldNotBeNull();
@@ -160,10 +160,10 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         {
             // Arrange
             var options = new AsyncApiOptions();
-            var documentGenerator = new DocumentGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(OneTenantMessageConsumer).GetTypeInfo() });
+            var document = documentGenerator.GenerateDocument(new []{ typeof(OneTenantMessageConsumer).GetTypeInfo() }, options);
             
             // Assert
             document.ShouldNotBeNull();
@@ -173,8 +173,8 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             channel.Key.ShouldBe("asw.tenant_service.{tenant_id}.{tenant_status}");
             channel.Value.Description.ShouldBe("A tenant events.");
             channel.Value.Parameters.Count.ShouldBe(2);
-            channel.Value.Parameters.Values.OfType<Parameter>().ShouldContain(p => p.Name == "tenant_id" && p.Schema != null && p.Description == "The tenant identifier.");
-            channel.Value.Parameters.Values.OfType<Parameter>().ShouldContain(p => p.Name == "tenant_status" && p.Schema != null && p.Description == "The tenant status.");
+            channel.Value.Parameters.Values.OfType<ParameterReference>().ShouldContain(p => p.Id == "tenant_id" && p.Value.Schema != null && p.Value.Description == "The tenant identifier.");
+            channel.Value.Parameters.Values.OfType<ParameterReference>().ShouldContain(p => p.Id == "tenant_status" && p.Value.Schema != null && p.Value.Description == "The tenant status.");
             
             var subscribe = channel.Value.Subscribe;
             subscribe.ShouldNotBeNull();

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
@@ -22,7 +22,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
             
             // Act
-            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() }, options);
+            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() }, options, options.AsyncApi);
 
             // Assert
             document.ShouldNotBeNull();
@@ -54,7 +54,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantGenericMessagePublisher).GetTypeInfo() }, options);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantGenericMessagePublisher).GetTypeInfo() }, options, options.AsyncApi);
 
             // Assert
             document.ShouldNotBeNull();
@@ -86,7 +86,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantSingleMessagePublisher).GetTypeInfo() }, options);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantSingleMessagePublisher).GetTypeInfo() }, options, options.AsyncApi);
 
             // Assert
             document.ShouldNotBeNull();
@@ -118,7 +118,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             {
                 typeof(TenantMessageConsumer).GetTypeInfo(),
                 typeof(TenantMessagePublisher).GetTypeInfo()
-            }, options);
+            }, options, options.AsyncApi);
 
             // Assert
             document.ShouldNotBeNull();
@@ -163,7 +163,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(OneTenantMessageConsumer).GetTypeInfo() }, options);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(OneTenantMessageConsumer).GetTypeInfo() }, options, options.AsyncApi);
             
             // Assert
             document.ShouldNotBeNull();

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
@@ -17,10 +17,10 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
         {
             // Arrange
             var options = new AsyncApiOptions();
-            var documentGenerator = new DocumentGenerator(Options.Create(options));
+            var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() });
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() }, options);
             
             // Assert
             document.ShouldNotBeNull();

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
@@ -20,7 +20,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() }, options);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() }, options, options.AsyncApi);
             
             // Assert
             document.ShouldNotBeNull();

--- a/test/Saunter.Tests/Generation/OperationTraitsTests.cs
+++ b/test/Saunter.Tests/Generation/OperationTraitsTests.cs
@@ -37,7 +37,8 @@ namespace Saunter.Tests.Generation
             using (var serviceprovider = services.BuildServiceProvider())
             {
                 var documentProvider = serviceprovider.GetRequiredService<IAsyncApiDocumentProvider>();
-                var document = documentProvider.GetDocument(serviceprovider.GetRequiredService<IOptions<AsyncApiOptions>>().Value);
+                var options = serviceprovider.GetRequiredService<IOptions<AsyncApiOptions>>().Value;
+                var document = documentProvider.GetDocument(options, options.AsyncApi);
 
                 document.Components.OperationTraits.ShouldContainKey("exampleTrait");
             }

--- a/test/Saunter.Tests/Generation/OperationTraitsTests.cs
+++ b/test/Saunter.Tests/Generation/OperationTraitsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Saunter.AsyncApiSchema.v2;
 using Saunter.AsyncApiSchema.v2.Traits;
 using Saunter.Generation;
@@ -36,7 +37,7 @@ namespace Saunter.Tests.Generation
             using (var serviceprovider = services.BuildServiceProvider())
             {
                 var documentProvider = serviceprovider.GetRequiredService<IAsyncApiDocumentProvider>();
-                var document = documentProvider.GetDocument();
+                var document = documentProvider.GetDocument(serviceprovider.GetRequiredService<IOptions<AsyncApiOptions>>().Value);
 
                 document.Components.OperationTraits.ShouldContainKey("exampleTrait");
             }

--- a/test/Saunter.Tests/ServiceCollectionTests.cs
+++ b/test/Saunter.Tests/ServiceCollectionTests.cs
@@ -59,7 +59,7 @@ namespace Saunter.Tests
 
             var provider = sp.GetRequiredService<IAsyncApiDocumentProvider>();
 
-            var document = provider.GetDocument(new AsyncApiOptions());
+            var document = provider.GetDocument(new AsyncApiOptions(), new AsyncApiDocument());
 
             document.ShouldNotBeNull();
         }

--- a/test/Saunter.Tests/ServiceCollectionTests.cs
+++ b/test/Saunter.Tests/ServiceCollectionTests.cs
@@ -59,7 +59,7 @@ namespace Saunter.Tests
 
             var provider = sp.GetRequiredService<IAsyncApiDocumentProvider>();
 
-            var document = provider.GetDocument();
+            var document = provider.GetDocument(new AsyncApiOptions());
 
             document.ShouldNotBeNull();
         }

--- a/test/Saunter.Tests/Utils/SerializerTests.cs
+++ b/test/Saunter.Tests/Utils/SerializerTests.cs
@@ -25,7 +25,7 @@ namespace Saunter.Tests.Utils
         [Fact]
         public void TestSerialize()
         {
-            var doc = _documentGenerator.GenerateDocument(new[] { typeof(MethodAttributesTests.TenantMessagePublisher).GetTypeInfo() }, _options);
+            var doc = _documentGenerator.GenerateDocument(new[] { typeof(MethodAttributesTests.TenantMessagePublisher).GetTypeInfo() }, _options, _options.AsyncApi);
             var serializedDoc = CreateSerializer().Serialize(doc, _options);
 
             serializedDoc.ShouldNotBeNullOrWhiteSpace();

--- a/test/Saunter.Tests/Utils/SerializerTests.cs
+++ b/test/Saunter.Tests/Utils/SerializerTests.cs
@@ -17,16 +17,16 @@ namespace Saunter.Tests.Utils
         public SerializerTests()
         {
             _options = new AsyncApiOptions();
-            _documentGenerator = new DocumentGenerator(Options.Create(_options));
+            _documentGenerator = new DocumentGenerator();
         }
 
-        protected abstract IAsyncApiDocumentSerializer CreateSerializer(IOptions<AsyncApiOptions> options);
+        protected abstract IAsyncApiDocumentSerializer CreateSerializer();
 
         [Fact]
         public void TestSerialize()
         {
-            var doc = _documentGenerator.GenerateDocument(new[] { typeof(MethodAttributesTests.TenantMessagePublisher).GetTypeInfo() });
-            var serializedDoc = CreateSerializer(Options.Create(_options)).Serialize(doc);
+            var doc = _documentGenerator.GenerateDocument(new[] { typeof(MethodAttributesTests.TenantMessagePublisher).GetTypeInfo() }, _options);
+            var serializedDoc = CreateSerializer().Serialize(doc, _options);
 
             serializedDoc.ShouldNotBeNullOrWhiteSpace();
         }
@@ -34,9 +34,9 @@ namespace Saunter.Tests.Utils
 
     public class NewtonsoftSerializerTests : SerializerTests
     {
-        protected override IAsyncApiDocumentSerializer CreateSerializer(IOptions<AsyncApiOptions> options)
+        protected override IAsyncApiDocumentSerializer CreateSerializer()
         {
-            return new NewtonsoftAsyncApiDocumentSerializer(options);
+            return new NewtonsoftAsyncApiDocumentSerializer();
         }
     }
 }


### PR DESCRIPTION
fixes #64

also contains some more null fixes related to njsonschema.

the concept revolves around having named options per api. that way most of the api can remain the same.

usage:

```csharp
public virtual void ConfigureServices(IServiceCollection services)
{
            services.AddAsyncApiSchemaGeneration();
            services.ConfigureNamedAsyncApi("A", asyncApi =>
            {
                  ....
                asyncApi.Middleware.Route = "/asyncapi/a/asyncapi.json";
                asyncApi.Middleware.UiBaseRoute = "/asyncapi/a/ui/";
            });

            services.ConfigureNamedAsyncApi("B", asyncApi =>
            {
                  ....
                asyncApi.Middleware.Route = "/asyncapi/b/asyncapi.json";
                asyncApi.Middleware.UiBaseRoute = "/asyncapi/b/ui/";
            });
}

public virtual void Configure(IApplicationBuilder app)
        {
              ...
            app.UseMiddleware<AsyncApiMiddleware>("A");
            app.UseMiddleware<AsyncApiMiddleware>("B");

            app.UseMiddleware<AsyncApiUiMiddleware>("A");
            app.UseMiddleware<AsyncApiUiMiddleware>("B");
        }


    [AsyncApi("A")]
    public class ASender {
   } 

    [AsyncApi("B")]
    public class BSender {} 
```