### PR TITLE
Filter Dependency Injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [v0.8.0] - 2021-09-11
+### Changed
+- Filters are now registered as types (e.g. `options.AddOperationFilter<T>`) and resolved from an `IServiceProvider`
+
 ## [v0.7.1] - 2021-08-04
 ### Fixed
 - Include XML documentation file in build (HOW HAD I NOT NOTICED THIS BEFORE?!)
@@ -102,7 +106,8 @@ Microsoft.NET.Test.Sdk 16.8.3 -> 16.10.0
 When updating here set baseVersion to the previous tag and targetVersion to your new tag
 This link will be dead until after you have completed the pull request and tagged the new version in master
 -->
-[Unreleased]: https://github.com/tehmantra/saunter/compare/v0.7.1...main
+[Unreleased]: https://github.com/tehmantra/saunter/compare/v0.8.0...main
+[v0.8.0]: https://github.com/tehmantra/saunter/compare/v0.7.1...v0.8.0
 [v0.7.1]: https://github.com/tehmantra/saunter/compare/v0.7.0...v0.7.1
 [v0.7.0]: https://github.com/tehmantra/saunter/compare/v0.6.0...v0.7.0
 [v0.6.0]: https://github.com/tehmantra/saunter/compare/v0.5.0...v0.6.0

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ services.AddAsyncApiSchemaGeneration(options =>
 {
     options.AssemblyMarkerTypes = new[] { typeof(Startup) };   // Tell Saunter where to scan for your classes.
     
-    options.ChannelItemFilters.Add(new MyChannelItemFilter()); // Dynamically update ChanelItems
-    options.OperationFilters.Add(new MyOperationFilter());     // Dynamically update Operations
+    options.AddChannelItemFilter<MyChannelItemFilter>();       // Dynamically update ChanelItems
+    options.AddOperationFilter<MyOperationFilter>();           // Dynamically update Operations
     
     options.Middleware.Route = "/asyncapi/asyncapi.json"       // AsyncAPI JSON document URL
     options.Middleware.UiBaseRoute = "/asyncapi/ui/";          // AsyncAPI UI URL

--- a/src/Saunter/AsyncApiOptions.cs
+++ b/src/Saunter/AsyncApiOptions.cs
@@ -12,6 +12,11 @@ namespace Saunter
 {
     public class AsyncApiOptions
     {
+        private readonly List<Type> _documentFilters = new List<Type>();
+        private readonly List<Type> _channelItemFilters = new List<Type>();
+        private readonly List<Type> _operationFilters = new List<Type>();
+
+
         /// <summary>
         /// The base asyncapi schema. This will be augmented with other information auto-discovered
         /// from attributes.
@@ -26,17 +31,44 @@ namespace Saunter
         /// <summary>
         /// A list of filters that will be applied to the generated AsyncAPI document.
         /// </summary>
-        public IList<IDocumentFilter> DocumentFilters { get; } = new List<IDocumentFilter>();
+        public IEnumerable<Type> DocumentFilters => _documentFilters;
 
         /// <summary>
         /// A list of filters that will be applied to any generated channels.
         /// </summary>
-        public IList<IChannelItemFilter> ChannelItemFilters { get; } = new List<IChannelItemFilter>();
+        public IEnumerable<Type> ChannelItemFilters => _channelItemFilters;
 
         /// <summary>
-        /// A list of filters that will be applied to any generated Publish operations.
+        /// A list of filters that will be applied to any generated Publish/Subscribe operations.
         /// </summary>
-        public IList<IOperationFilter> OperationFilters { get; } = new List<IOperationFilter>();
+        public IEnumerable<Type> OperationFilters => _operationFilters;
+
+
+        /// <summary>
+        /// Add a filter to be applied to the generated AsyncAPI document.
+        /// </summary>
+        public void AddDocumentFilter<T>() where T : IDocumentFilter
+        {
+            _documentFilters.Add(typeof(T));
+        }
+
+        /// <summary>
+        /// Add a filter to be applied to any generated channels.
+        /// </summary>
+        public void AddChannelItemFilter<T>() where T : IChannelItemFilter
+        {
+            _channelItemFilters.Add(typeof(T));
+        }
+
+        /// <summary>
+        /// Add a filter to be applied to any generated Publish/Subscribe operations.
+        /// </summary>
+        public void AddOperationFilter<T>() where T : IOperationFilter
+        {
+            _operationFilters.Add(typeof(T));
+        }
+
+
 
         /// <summary>
         /// Options related to the Saunter middleware.

--- a/src/Saunter/Generation/AsyncApiDocumentProvider.cs
+++ b/src/Saunter/Generation/AsyncApiDocumentProvider.cs
@@ -9,10 +9,12 @@ namespace Saunter.Generation
     public class AsyncApiDocumentProvider : IAsyncApiDocumentProvider
     {
         private readonly IDocumentGenerator _documentGenerator;
+        private readonly IServiceProvider _serviceProvider;
 
-        public AsyncApiDocumentProvider(IDocumentGenerator documentGenerator)
+        public AsyncApiDocumentProvider(IDocumentGenerator documentGenerator, IServiceProvider serviceProvider)
         {
             _documentGenerator = documentGenerator;
+            _serviceProvider = serviceProvider;
         }
 
         public AsyncApiDocument GetDocument(AsyncApiOptions options, AsyncApiDocument prototype)
@@ -23,7 +25,7 @@ namespace Saunter.Generation
             }
             var asyncApiTypes = GetAsyncApiTypes(options, prototype);
 
-            var document = _documentGenerator.GenerateDocument(asyncApiTypes, options, prototype);
+            var document = _documentGenerator.GenerateDocument(asyncApiTypes, options, prototype, _serviceProvider);
 
             return document;
         }

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Saunter.AsyncApiSchema.v2.Bindings;
 using Saunter.Utils;
 
@@ -31,7 +32,7 @@ namespace Saunter.Generation
             var filterContext = new DocumentFilterContext(asyncApiTypes, schemaResolver, generator);
             foreach (var filterType in options.DocumentFilters)
             {
-                var filter = serviceProvider.GetService(filterType) as IDocumentFilter;
+                var filter = (IDocumentFilter)serviceProvider.GetRequiredService(filterType);
                 filter?.Apply(asyncApiSchema, filterContext);
             }
 
@@ -82,8 +83,8 @@ namespace Saunter.Generation
                 var context = new ChannelItemFilterContext(mc.Method, schemaResolver, jsonSchemaGenerator, mc.Channel);
                 foreach (var filterType in options.ChannelItemFilters)
                 {
-                    var filter = serviceProvider.GetService(filterType) as IChannelItemFilter;
-                    filter?.Apply(channelItem, context);
+                    var filter = (IChannelItemFilter)serviceProvider.GetRequiredService(filterType);
+                    filter.Apply(channelItem, context);
                 }
             }
 
@@ -122,8 +123,8 @@ namespace Saunter.Generation
                 var context = new ChannelItemFilterContext(cc.Type, schemaResolver, jsonSchemaGenerator, cc.Channel);
                 foreach (var filterType in options.ChannelItemFilters)
                 {
-                    var filter = serviceProvider.GetService(filterType) as IChannelItemFilter;
-                    filter?.Apply(channelItem, context);
+                    var filter = (IChannelItemFilter)serviceProvider.GetRequiredService(filterType);
+                    filter.Apply(channelItem, context);
                 }
             }
 
@@ -158,7 +159,7 @@ namespace Saunter.Generation
             var filterContext = new OperationFilterContext(method, schemaResolver, jsonSchemaGenerator, operationAttribute);
             foreach (var filterType in options.OperationFilters)
             {
-                var filter = serviceProvider.GetService(filterType) as IOperationFilter;
+                var filter = (IOperationFilter)serviceProvider.GetRequiredService(filterType);
                 filter?.Apply(operation, filterContext);
             }
 

--- a/src/Saunter/Generation/IDocumentGenerator.cs
+++ b/src/Saunter/Generation/IDocumentGenerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Saunter.AsyncApiSchema.v2;
 
@@ -5,6 +6,6 @@ namespace Saunter.Generation
 {
     public interface IDocumentGenerator
     {
-        AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options, AsyncApiDocument prototype);
+        AsyncApiDocument GenerateDocument(TypeInfo[] asyncApiTypes, AsyncApiOptions options, AsyncApiDocument prototype, IServiceProvider serviceProvider);
     }
 }

--- a/test/Saunter.Tests/ActivatorServiceProvider.cs
+++ b/test/Saunter.Tests/ActivatorServiceProvider.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Saunter.Tests
+{
+    public class ActivatorServiceProvider : IServiceProvider
+    {
+        public static readonly IServiceProvider Instance = new ActivatorServiceProvider();
+
+        public object GetService(Type serviceType)
+        {
+            return Activator.CreateInstance(serviceType);
+        }
+    }
+}

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/ClassAttributesTests.cs
@@ -1,12 +1,9 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Microsoft.Extensions.Options;
-using NJsonSchema.Generation;
 using Saunter.AsyncApiSchema.v2;
 using Saunter.Attributes;
 using Saunter.Generation;
-using Saunter.Generation.SchemaGeneration;
 using Shouldly;
 using Xunit;
 
@@ -22,7 +19,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
             
             // Act
-            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() }, options, options.AsyncApi);
+            var document = documentGenerator.GenerateDocument(new[] { typeof(TenantMessageConsumer).GetTypeInfo() }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
 
             // Assert
             document.ShouldNotBeNull();
@@ -54,7 +51,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantGenericMessagePublisher).GetTypeInfo() }, options, options.AsyncApi);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantGenericMessagePublisher).GetTypeInfo() }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
 
             // Assert
             document.ShouldNotBeNull();
@@ -86,7 +83,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantSingleMessagePublisher).GetTypeInfo() }, options, options.AsyncApi);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantSingleMessagePublisher).GetTypeInfo() }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
 
             // Assert
             document.ShouldNotBeNull();
@@ -118,7 +115,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             {
                 typeof(TenantMessageConsumer).GetTypeInfo(),
                 typeof(TenantMessagePublisher).GetTypeInfo()
-            }, options, options.AsyncApi);
+            }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
 
             // Assert
             document.ShouldNotBeNull();
@@ -163,7 +160,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(OneTenantMessageConsumer).GetTypeInfo() }, options, options.AsyncApi);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(OneTenantMessageConsumer).GetTypeInfo() }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
             
             // Assert
             document.ShouldNotBeNull();

--- a/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentGeneratorTests/MethodAttributesTests.cs
@@ -20,7 +20,7 @@ namespace Saunter.Tests.Generation.DocumentGeneratorTests
             var documentGenerator = new DocumentGenerator();
 
             // Act
-            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() }, options, options.AsyncApi);
+            var document = documentGenerator.GenerateDocument(new []{ typeof(TenantMessagePublisher).GetTypeInfo() }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
             
             // Assert
             document.ShouldNotBeNull();

--- a/test/Saunter.Tests/Generation/Filters/DocumentFilterTests.cs
+++ b/test/Saunter.Tests/Generation/Filters/DocumentFilterTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using Saunter.AsyncApiSchema.v2;
+using Saunter.Generation;
+using Saunter.Generation.Filters;
+using Shouldly;
+using Xunit;
+
+namespace Saunter.Tests.Generation.Filters
+{
+    public class DocumentFilterTests
+    {
+        [Fact]
+        public void DocumentFilterIsAppliedToAsyncApiDocument()
+        {
+            // Arrange
+            var options = new AsyncApiOptions();
+            var documentGenerator = new DocumentGenerator();
+
+            // Act
+            options.AddDocumentFilter<ExampleDocumentFilter>();
+            var document = documentGenerator.GenerateDocument(new[] { GetType().GetTypeInfo() }, options, options.AsyncApi, ActivatorServiceProvider.Instance);
+
+            // Assert
+            document.ShouldNotBeNull();
+            document.Channels.Count.ShouldBe(1);
+            document.Channels.ShouldContainKey("foo");
+        }
+
+
+        private class ExampleDocumentFilter : IDocumentFilter
+        {
+            public void Apply(AsyncApiDocument document, DocumentFilterContext context)
+            {
+                var channel = new ChannelItem
+                {
+                    Description = "an example channel for testing"
+                };
+
+                document.Channels.Add(new KeyValuePair<string, ChannelItem>("foo", channel));
+            }
+        }
+    }
+}

--- a/test/Saunter.Tests/Generation/OperationTraitsTests.cs
+++ b/test/Saunter.Tests/Generation/OperationTraitsTests.cs
@@ -31,7 +31,7 @@ namespace Saunter.Tests.Generation
                     }
                 };
 
-                o.OperationFilters.Add(new TestOperationTraitsFilter());
+                o.AddOperationFilter<TestOperationTraitsFilter>();
             });
 
             using (var serviceprovider = services.BuildServiceProvider())

--- a/test/Saunter.Tests/Utils/SerializerTests.cs
+++ b/test/Saunter.Tests/Utils/SerializerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Saunter.Generation;
 using Saunter.Serialization;
@@ -25,7 +27,7 @@ namespace Saunter.Tests.Utils
         [Fact]
         public void TestSerialize()
         {
-            var doc = _documentGenerator.GenerateDocument(new[] { typeof(MethodAttributesTests.TenantMessagePublisher).GetTypeInfo() }, _options, _options.AsyncApi);
+            var doc = _documentGenerator.GenerateDocument(new[] { typeof(MethodAttributesTests.TenantMessagePublisher).GetTypeInfo() }, _options, _options.AsyncApi, ActivatorServiceProvider.Instance);
             var serializedDoc = CreateSerializer().Serialize(doc, _options);
 
             serializedDoc.ShouldNotBeNullOrWhiteSpace();


### PR DESCRIPTION
- Filters are now registered as types (e.g. `options.AddOperationFilter<T>`) and resolved from an `IServiceProvider`

Fixes #116