### PR TITLE
Update dependencies, add dotnet6 target

### DIFF
--- a/src/Saunter.UI/package.json
+++ b/src/Saunter.UI/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@asyncapi/react-component": "^1.0.0-next.21"
+    "@asyncapi/react-component": "^1.0.0-next.26"
   }
 }

--- a/src/Saunter/Saunter.csproj
+++ b/src/Saunter/Saunter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;netstandard2.0;net6.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>Saunter</PackageId>
     <Title>Saunter</Title>
@@ -47,11 +47,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="3.0.0" />
-    <PackageReference Include="Namotion.Reflection" Version="1.0.23" />
-    <PackageReference Include="NJsonSchema" Version="10.4.6" />
+    <PackageReference Include="Namotion.Reflection" Version="2.0.9" />
+    <PackageReference Include="NJsonSchema" Version="10.6.6" />
 
     <!-- Development Dependencies -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">


### PR DESCRIPTION
I was having recursion issues with the current release of Saunter, updating NJsonSchema and Namotion.Reflection fixed the issue.