### PR TITLE
Fixes asyncapi parser errors when using Tags

### DIFF
--- a/examples/StreetlightsAPI/API.cs
+++ b/examples/StreetlightsAPI/API.cs
@@ -91,7 +91,7 @@ namespace StreetlightsAPI
         /// Inform about environmental lighting conditions for a particular streetlight.
         /// </summary>
         [Channel(PublishLightMeasuredTopic, Servers = new []{"webapi"})]
-        [PublishOperation(typeof(LightMeasuredEvent))]
+        [PublishOperation(typeof(LightMeasuredEvent), "Light")]
         [HttpPost]
         [Route(PublishLightMeasuredTopic)]
         public void MeasureLight([FromBody] LightMeasuredEvent lightMeasuredEvent)

--- a/examples/StreetlightsAPI/Messaging.cs
+++ b/examples/StreetlightsAPI/Messaging.cs
@@ -22,7 +22,7 @@ namespace StreetlightsAPI
         }
 
         [Channel(SubscribeLightMeasuredTopic, Servers = new[] { "mosquitto" })]
-        [SubscribeOperation(typeof(LightMeasuredEvent), Summary = "Subscribe to environmental lighting conditions for a particular streetlight.")]
+        [SubscribeOperation(typeof(LightMeasuredEvent), "Light", Summary = "Subscribe to environmental lighting conditions for a particular streetlight.")]
         public void PublishLightMeasurement(LightMeasuredEvent lightMeasuredEvent)
         {
             var payload = JsonSerializer.Serialize(lightMeasuredEvent);

--- a/src/Saunter/AsyncApiSchema/v2/Tag.cs
+++ b/src/Saunter/AsyncApiSchema/v2/Tag.cs
@@ -19,13 +19,13 @@ namespace Saunter.AsyncApiSchema.v2
         /// <summary>
         /// A short description for the tag. CommonMark syntax can be used for rich text representation.
         /// </summary>
-        [JsonProperty("description")]
+        [JsonProperty("description", NullValueHandling = NullValueHandling.Ignore)]
         public string Description { get; set; }
 
         /// <summary>
         /// Additional external documentation for this tag.
         /// </summary>
-        [JsonProperty("externalDocs")]
+        [JsonProperty("externalDocs", NullValueHandling = NullValueHandling.Ignore)]
         public ExternalDocumentation ExternalDocs { get; set; }
 
         public static implicit operator Tag(string s)

--- a/src/Saunter/Generation/DocumentGenerator.cs
+++ b/src/Saunter/Generation/DocumentGenerator.cs
@@ -192,6 +192,7 @@ namespace Saunter.Generation
                 Description = operationAttribute.Description ?? (type.GetXmlDocsRemarks() != "" ? type.GetXmlDocsRemarks() : null),
                 Message = messages,
                 Bindings = operationAttribute.BindingsRef != null ? new OperationBindingsReference(operationAttribute.BindingsRef) : null,
+                Tags = new HashSet<Tag>( operationAttribute.Tags?.Select(x => new Tag(x)) ?? new List<Tag>())
             };
 
             var methodsWithMessageAttribute = type.DeclaredMethods


### PR DESCRIPTION
- Updates Tag Description and ExternalDocs to ignore nulls to eliminate async api parser errors.
- Updates example to use Tags
- Adds support for Tags from a class that was missing.