### PR TITLE
Fix duplicate operation when multiple types of the same assembly are used in AssemblyMarkerTypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 <!-- Please update the links section at the bottom when adding a new version. -->
 
+## [v0.11.1] - 2023-04-12
+### Fixed
+- [Duplicated operation when types of the same assembly are used in AssemblyMarkerTypes](https://github.com/tehmantra/saunter/issues/163)
+
 ## [v0.11.0] - 2022-10-03
 ### Added
 - Message and Operation attributes now allow setting tags
@@ -135,6 +139,7 @@ When updating here set baseVersion to the previous tag and targetVersion to your
 This link will be dead until after you have completed the pull request and tagged the new version in master
 -->
 
+[v0.11.1]: https://github.com/tehmantra/saunter/compare/v0.11.0...v0.11.1
 [v0.11.0]: https://github.com/tehmantra/saunter/compare/v0.10.0...v0.11.0
 [v0.10.0]: https://github.com/tehmantra/saunter/compare/v0.9.1...v0.10.0
 [v0.9.1]: https://github.com/tehmantra/saunter/compare/v0.9.0...v0.9.1

--- a/Saunter.Tests.MarkerTypeTests/Broker.cs
+++ b/Saunter.Tests.MarkerTypeTests/Broker.cs
@@ -1,0 +1,25 @@
+﻿using Saunter.Attributes;
+
+namespace Saunter.Tests.MarkerTypeTests
+{
+    [AsyncApi]
+    [Channel("asw.sample_service.anothersample", Description = "Another sample events.")]
+    [PublishOperation(OperationId = "AnotherSampleMessagePublisher", Summary = "Publish another sample.")]
+    public class AnotherSamplePublisher
+    {
+        [Message(typeof(AnotherSampleMesssage))]
+        public void PublishTenantCreated(AnotherSampleMesssage @event) { }
+    }
+
+    [AsyncApi]
+    [Channel("asw.sample_service.sample", Description = "Sample events.")]
+    [SubscribeOperation(OperationId = "SampleMessageConsumer", Summary = "Consume sample messages.")]
+    public class SampleConsumer
+    {
+        [Message(typeof(SampleMessage))]
+        public void SubscribeSampleMessage(SampleMessage evnt) { }
+    }
+
+    public class SampleMessage { }
+    public class AnotherSampleMesssage { }
+}

--- a/Saunter.Tests.MarkerTypeTests/Saunter.Tests.MarkerTypeTests.csproj
+++ b/Saunter.Tests.MarkerTypeTests/Saunter.Tests.MarkerTypeTests.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Saunter\Saunter.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Saunter.sln
+++ b/Saunter.sln
@@ -18,12 +18,14 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{E0D34C77-924E-4F6B-9289-5A2F07D125A8}"
 	ProjectSection(SolutionItems) = preProject
 		CHANGELOG.md = CHANGELOG.md
-		README.md = README.md
 		.github\workflows\ci.yaml = .github\workflows\ci.yaml
+		README.md = README.md
 		.github\workflows\release.yaml = .github\workflows\release.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Saunter.IntegrationTests.ReverseProxy", "test\Saunter.IntegrationTests.ReverseProxy\Saunter.IntegrationTests.ReverseProxy.csproj", "{7CD09B89-130A-41AF-ADAE-2166C4ED695B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Saunter.Tests.MarkerTypeTests", "Saunter.Tests.MarkerTypeTests\Saunter.Tests.MarkerTypeTests.csproj", "{02284473-6DE7-4EE0-8433-2AC295045549}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -83,6 +85,18 @@ Global
 		{7CD09B89-130A-41AF-ADAE-2166C4ED695B}.Release|x64.Build.0 = Release|Any CPU
 		{7CD09B89-130A-41AF-ADAE-2166C4ED695B}.Release|x86.ActiveCfg = Release|Any CPU
 		{7CD09B89-130A-41AF-ADAE-2166C4ED695B}.Release|x86.Build.0 = Release|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Debug|x64.Build.0 = Debug|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Debug|x86.Build.0 = Debug|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Release|Any CPU.Build.0 = Release|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Release|x64.ActiveCfg = Release|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Release|x64.Build.0 = Release|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Release|x86.ActiveCfg = Release|Any CPU
+		{02284473-6DE7-4EE0-8433-2AC295045549}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,6 +106,7 @@ Global
 		{3ADB27EF-7C80-40EB-AFC6-5D06D415FFAB} = {6491E321-2D02-44AB-9116-D722FE169595}
 		{F188D4A7-BBCB-464F-A370-2BD84D18EA79} = {6ABD4842-47AF-49A5-B057-0EBA64416789}
 		{7CD09B89-130A-41AF-ADAE-2166C4ED695B} = {6491E321-2D02-44AB-9116-D722FE169595}
+		{02284473-6DE7-4EE0-8433-2AC295045549} = {6491E321-2D02-44AB-9116-D722FE169595}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2F85D9DA-DBCF-4F13-8C42-5719F1469B2E}

--- a/src/Saunter/Generation/AsyncApiDocumentProvider.cs
+++ b/src/Saunter/Generation/AsyncApiDocumentProvider.cs
@@ -36,7 +36,7 @@ namespace Saunter.Generation
         /// </summary>
         private static TypeInfo[] GetAsyncApiTypes(AsyncApiOptions options, AsyncApiDocument prototype)
         {
-            var assembliesToScan = options.AssemblyMarkerTypes.Select(t => t.Assembly);
+            var assembliesToScan = options.AssemblyMarkerTypes.Select(t => t.Assembly).Distinct();
 
             var asyncApiTypes = assembliesToScan
                 .SelectMany(a => a.DefinedTypes.Where(t => t.GetCustomAttribute<AsyncApiAttribute>()?.DocumentName == prototype.DocumentName))

--- a/test/Saunter.Tests/Generation/DocumentProviderTests/AsyncApiTypesTests.cs
+++ b/test/Saunter.Tests/Generation/DocumentProviderTests/AsyncApiTypesTests.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Saunter.AsyncApiSchema.v2;
+using Saunter.Attributes;
+using Saunter.Tests.MarkerTypeTests;
+using Shouldly;
+using Xunit;
+
+namespace Saunter.Tests.Generation.DocumentProviderTests
+{
+    public class AsyncApiTypesTests
+    {
+        [Fact]
+        public void GetDocument_GeneratesDocumentWithMultipleMessagesPerChannel()
+        {
+            var services = new ServiceCollection() as IServiceCollection;
+            services.AddAsyncApiSchemaGeneration(o =>
+            {
+                o.AsyncApi = new AsyncApiDocument
+                {
+                    Info = new Info(GetType().FullName, "1.0.0")
+                };
+                o.AssemblyMarkerTypes = new[] { typeof(AnotherSamplePublisher), typeof(SampleConsumer) };
+            });
+
+            using (var serviceprovider = services.BuildServiceProvider())
+            {
+                var documentProvider = serviceprovider.GetRequiredService<IAsyncApiDocumentProvider>();
+                var options = serviceprovider.GetRequiredService<IOptions<AsyncApiOptions>>().Value;
+                var document = documentProvider.GetDocument(options, options.AsyncApi);
+
+                document.ShouldNotBeNull();
+            }
+        }
+
+        
+    }
+}

--- a/test/Saunter.Tests/Saunter.Tests.csproj
+++ b/test/Saunter.Tests/Saunter.Tests.csproj
@@ -28,6 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\Saunter.Tests.MarkerTypeTests\Saunter.Tests.MarkerTypeTests.csproj" />
     <ProjectReference Include="..\..\src\Saunter\Saunter.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
- Update Scanner to Distinct Assemblies before generating documentation

Fixes: #163 